### PR TITLE
Signing: display the signer account rather than the selected one

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -27,7 +27,7 @@ const networkLinks: Record<NetworkName, Record<LinkName, string>> = {
   }
 };
 
-const defaultNetwork: NetworkName = NetworkName.pme;
+const defaultNetwork: NetworkName = NetworkName.alcyone;
 
 const messagePrefix = 'poly:';
 

--- a/packages/core/src/store/getters.ts
+++ b/packages/core/src/store/getters.ts
@@ -1,7 +1,7 @@
-import { accountsCount, network, networkUrl, selectedAccount, didsList, accountsAddresses } from './selectors';
+import { accountsCount, network, networkUrl, selectedAccount, didsList, accountsAddresses, identifiedAccounts } from './selectors';
 
 import store from '.';
-import { NetworkName } from '../types';
+import { IdentifiedAccount, NetworkName } from '../types';
 
 function getNetwork (): NetworkName {
   return network(store.getState());
@@ -27,11 +27,16 @@ function getAccountsList (): string[] {
   return accountsAddresses(store.getState());
 }
 
+function getIdentifiedAccounts (): IdentifiedAccount[] {
+  return identifiedAccounts(store.getState());
+}
+
 export {
   getNetwork,
   getNetworkUrl,
   getSelectedAccount,
   getAccountsCount,
   getDids,
-  getAccountsList
+  getAccountsList,
+  getIdentifiedAccounts
 };

--- a/packages/ui/src/Popup/Signing/Request.tsx
+++ b/packages/ui/src/Popup/Signing/Request.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useContext, useState, useEffect } from 'react';
 import { TypeRegistry } from '@polkadot/types';
 
 import { ActionContext, ActivityContext } from '../../components';
-import { Button } from '../../ui';
+import { Button, Box, Flex } from '../../ui';
 
 import { approveSignPassword, approveSignSignature, cancelSignRequest, isSignLocked } from '../../messaging';
 import Bytes from './Bytes';
@@ -150,12 +150,27 @@ export default function Request ({ account: { isExternal }, isFirst, request, si
       />
     )
     : (
-      <Button busy={isBusy}
-        disabled={isLocked === null}
-        onClick={_onSignQuick}
-      >
-        Sign
-      </Button>
+      <Flex flex={2}
+        flexDirection='row'
+        mb='s'
+        mx='xs'>
+        <Box mx='xs'>
+          <Button
+            fluid
+            onClick={_onCancel}
+            variant='secondary'>
+            Reject
+          </Button>
+        </Box>
+        {isFirst && <Box mx='xs'>
+          <Button busy={isBusy}
+            disabled={isLocked === null}
+            fluid
+            onClick={_onSignQuick}>
+            Sign
+          </Button>
+        </Box> }
+      </Flex>
     );
 
   return (

--- a/packages/ui/src/Popup/Signing/index.tsx
+++ b/packages/ui/src/Popup/Signing/index.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
-import { Loading, PolymeshContext, SigningReqContext } from '../../components';
+import { Loading, SigningReqContext } from '../../components';
 import Request from './Request';
 import TransactionIndex from './TransactionIndex';
-import { Box, Header, Text } from '@polymathnetwork/extension-ui/ui';
+import { Box, Header, ScrollableContainer, Text } from '@polymathnetwork/extension-ui/ui';
 import AccountsHeader from '../Accounts/AccountsHeader';
+import { getIdentifiedAccounts } from '@polymathnetwork/extension-core/store/getters';
 
 export default function Signing (): React.ReactElement {
   const requests = useContext(SigningReqContext);
-  const { currentAccount } = useContext(PolymeshContext);
   const [requestIndex, setRequestIndex] = useState(0);
 
   const _onNextClick = useCallback(
@@ -37,11 +37,15 @@ export default function Signing (): React.ReactElement {
       : requests[0]
     : null;
 
+  // The singing account, whose details will be displayed in the header.
+  const signingAccount = request &&
+  getIdentifiedAccounts().find((account) => account.address === request?.account.address);
+
   return request
     ? (
       <>
         <Header>
-          {currentAccount && <AccountsHeader account={currentAccount}
+          {signingAccount && <AccountsHeader account={signingAccount}
             details={false} />}
           <Box>
             <Text color='gray.0'
@@ -57,13 +61,15 @@ export default function Signing (): React.ReactElement {
             </Text>
           </Box>
         </Header>
-        <Request
-          account={request.account}
-          isFirst={requestIndex === 0}
-          request={request.request}
-          signId={request.id}
-          url={request.url}
-        />
+        <ScrollableContainer>
+          <Request
+            account={request.account}
+            isFirst={requestIndex === 0}
+            request={request.request}
+            signId={request.id}
+            url={request.url}
+          />
+        </ScrollableContainer>
       </>
     )
     : <Loading />;


### PR DESCRIPTION
Also:
- Wrap signing dialog details with a scrollable container.
- Set default network to `Alcyone`.
- Bring `Reject` button to signing dialog, in case user had saved their password.