### PR TITLE
Remove handling of meta injection requests

### DIFF
--- a/packages/core/src/background/handlers/Tabs.ts
+++ b/packages/core/src/background/handlers/Tabs.ts
@@ -102,6 +102,20 @@ export default class Tabs {
       case 'pub(accounts.subscribe)':
         return this.accountsSubscribe(url, id, port);
 
+      case 'pub(metadata.list)': {
+        // Deny app's request to provide metadata because Polymesh wallet
+        // is fully aware of network metadata via ApiPromise objects.
+
+        return [];
+      }
+
+      case 'pub(metadata.provide)': {
+        // Deny app's request to provide metadata because Polymesh wallet
+        // is fully aware of network metadata via ApiPromise objects.
+
+        return false;
+      }
+
       default:
         throw new Error(`Unable to handle message of type ${type}`);
     }

--- a/packages/core/src/background/types.ts
+++ b/packages/core/src/background/types.ts
@@ -2,8 +2,7 @@ import { IdentifiedAccount, NetworkMeta, NetworkName, StoreStatus } from '../typ
 import { SignerPayloadJSON, AnyJson } from '@polkadot/types/types';
 import { FunctionMetadataLatest } from '@polkadot/types/interfaces';
 import { RequestAccountList, RequestAccountSubscribe } from '@polkadot/extension-base/background/types';
-import { InjectedAccount } from '@polkadot/extension-inject/types';
-
+import { InjectedAccount, MetadataDef, InjectedMetadataKnown } from '@polkadot/extension-inject/types';
 export interface ResponsePolyCallDetails {
   networkFee: string,
   protocolFee: string,
@@ -54,10 +53,13 @@ export interface PolyRequestSignatures {
   'poly:pri(identity.rename)': [RequestPolyIdentityRename, boolean];
   'poly:pub(network.get)': [RequestPolyNetworkGet, NetworkMeta];
   'poly:pub(network.subscribe)': [RequestPolyNetworkMetaSubscribe, boolean, NetworkMeta];
-  // @FIXME this is an inelegant way to take over these two requests from Polkadot, in order to get
+  // this is an inelegant way to take over these couple requests from Polkadot,
+  // in order to alter the behavior as needed for each request respectively.
   // to re-order accounts list based on account selection.
   'pub(accounts.list)': [RequestAccountList, InjectedAccount[]];
   'pub(accounts.subscribe)': [RequestAccountSubscribe, boolean, InjectedAccount[]];
+  'pub(metadata.list)': [null, InjectedMetadataKnown[]];
+  'pub(metadata.provide)': [MetadataDef, boolean];
 }
 
 declare type IsNull<T, K extends keyof T> = {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -31,10 +31,17 @@ const defaultNetwork: NetworkName = NetworkName.alcyone;
 
 const messagePrefix = 'poly:';
 
+const messages = [
+  'pub(accounts.list)',
+  'pub(accounts.subscribe)',
+  'pub(metadata.provide)'
+];
+
 export {
   networkURLs,
   networkLabels,
   networkLinks,
   defaultNetwork,
-  messagePrefix
+  messagePrefix,
+  messages
 };

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,6 +1,6 @@
 import accountsObservable from '@polkadot/ui-keyring/observable/accounts';
 import { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
-import { messagePrefix } from './constants';
+import { messagePrefix, messages } from './constants';
 import { setError } from './store/setters';
 import { ErrorCodes, KeyringAccountData } from './types';
 
@@ -12,9 +12,9 @@ export function prioritize<P, T> (first: P, extractor: (a: T) => P) {
 }
 
 export function isPolyMessage (message: string): boolean {
-  return message.indexOf(messagePrefix) === 0 ||
-  message === 'pub(accounts.list)' ||
-  message === 'pub(accounts.subscribe)';
+  const isPolyMessage = message.indexOf(messagePrefix) === 0 || messages.indexOf(message) > -1;
+
+  return isPolyMessage;
 }
 
 export function observeAccounts (cb: (accounts: KeyringAccountData[]) => void) {


### PR DESCRIPTION
Accessing Polkadot/apps using Polymesh wallet, user will be asked to inject network metadata (token name, decimals...etc), into that wallet. That is a useful feature for a network agnostic wallet such as Polkadot, but not to our network-specific wallet. Hence, this PR removes handling of those requests because otherwise, user wallet will popup and leave user confused about how to proceed.

To test, go the following tab in polkadot/app, and make sure that clicking on "update" does nothing at all.

<img width="956" alt="Screen Shot 2020-11-03 at 3 36 54 PM" src="https://user-images.githubusercontent.com/1994818/98052649-950b5500-1deb-11eb-9d8c-619751cd53f1.png">
