### PR TITLE
Auth dialog: display hostname only instead of full url

### DIFF
--- a/packages/ui/src/Popup/Authorize/Request.tsx
+++ b/packages/ui/src/Popup/Authorize/Request.tsx
@@ -60,7 +60,7 @@ function Request ({ authId, isFirst, request: { origin }, url }: Props): React.R
                   rel='noopener noreferrer'
                   target='_blank'
                 >
-                  <span className='tab-url'>{url}</span>
+                  <span className='tab-url'>{(new URL(url)).hostname}</span>
                 </a>.
               </Text>
             </Box>


### PR DESCRIPTION
<img width="341" alt="Screen Shot 2020-11-25 at 7 48 34 AM" src="https://user-images.githubusercontent.com/1994818/100250744-dc6c9900-2ef2-11eb-8e75-d1bd5054dc33.png">
