### PR TITLE
feat: update account card UI (WAL-122)

### DIFF
--- a/packages/ui/src/Popup/Accounts/AccountView.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountView.tsx
@@ -4,7 +4,7 @@ import { SvgCheck, SvgDotsVertical, SvgPencilOutline, SvgWindowClose } from '@po
 import BigNumber from 'bignumber.js';
 import React, { FC, useContext, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import styled from 'styled-components'
+import styled from 'styled-components';
 
 import { AccountType, ActionContext, PolymeshContext } from '../../components';
 import { editAccount, setPolySelectedAccount } from '../../messaging';
@@ -158,13 +158,12 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
         {!isEditing && (
           <GridItem area='name'>
             <Flex
-              alignItems=''
               flexDirection='row'
               onMouseEnter={nameMouseEnter}
               onMouseLeave={nameMouseLeave}
             >
               <TextOverflowEllipsis
-                width='100px'
+                maxWidth='100px'
                 color='gray.1'
                 variant='b2m'
               >
@@ -200,11 +199,7 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
         </GridItem>
         <GridItem area='balance'>
           <Flex height='100%' justifyContent='flex-end'>
-            <Text
-              color='gray.1'
-              variant='b3'
-              style={{ whiteSpace: 'nowrap' }}
-            >
+            <Text color='gray.1' variant='b3' style={{ whiteSpace: 'nowrap' }}>
               {formatters.formatAmount(new BigNumber(balance || 0), 2, true)}{' '}
               POLYX
             </Text>
@@ -225,64 +220,80 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
 
   const renderHoverAccountInfo = () => {
     return (
-      <>
-        <Flex
-          flexDirection='row'
-          justifyContent='space-between'
-        >
-          <Box>
-            {isEditing && (
-              <Flex flexDirection='row'>
-                <TextInput defaultValue={name}
-                  onChange={handleNameChange}
-                  tight
-                  value={newName} />
-                <Box ml='xs'>
-                  <Icon Asset={SvgCheck}
-                    color='gray.2'
-                    height={16}
-                    onClick={save}
-                    width={16} />
-                </Box>
-                <Box ml='xs'>
-                  <Icon Asset={SvgWindowClose}
-                    color='gray.2'
-                    height={16}
-                    onClick={cancelEditing}
-                    width={16} />
-                </Box>
+      <UnassignedAccountHoverGrid>
+        {isEditing && (
+          <GridItem area='name-edit'>
+            <Flex flexDirection='row'>
+              <TextInput
+                defaultValue={name}
+                onChange={handleNameChange}
+                tight
+                value={newName}
+              />
+              <Box ml='xs'>
+                <Icon
+                  Asset={SvgCheck}
+                  color='gray.2'
+                  height={16}
+                  onClick={save}
+                  width={16}
+                />
+              </Box>
+              <Box ml='xs'>
+                <Icon
+                  Asset={SvgWindowClose}
+                  color='gray.2'
+                  height={16}
+                  onClick={cancelEditing}
+                  width={16}
+                />
+              </Box>
+            </Flex>
+          </GridItem>
+        )}
+        {!isEditing && (
+          <GridItem area='name'>
+            <Flex
+              flexDirection='row'
+              onMouseEnter={nameMouseEnter}
+              onMouseLeave={nameMouseLeave}
+            >
+              <TextOverflowEllipsis
+                maxWidth='100px'
+                color='gray.1'
+                variant='b2m'
+              >
+                {name}
+              </TextOverflowEllipsis>
+              <Flex ml='xs'>
+                <Icon
+                  Asset={SvgPencilOutline}
+                  color={nameHover ? 'gray.2' : 'gray.5'}
+                  height={16}
+                  onClick={editName}
+                  style={{ cursor: 'pointer' }}
+                  width={16}
+                />
               </Flex>
-            )}
-            {!isEditing && (
-              <Flex flexDirection='row'
-                onMouseEnter={nameMouseEnter}
-                onMouseLeave={nameMouseLeave}>
-                <Text color='gray.1'
-                  variant='b2m'>
-                  {name}
-                </Text>
-                <Flex ml='xs'>
-                  <Icon Asset={SvgPencilOutline}
-                    color={nameHover ? 'gray.2' : 'gray.5'}
-                    height={16}
-                    onClick={editName}
-                    style={{ cursor: 'pointer' }}
-                    width={16} />
-                </Flex>
-              </Flex>
-            )}
-            <LabelWithCopy color='gray.3'
-              text={address}
-              textSize={13}
-              textVariant='b3'
-            />
-          </Box>
-          <Box>
-            <ButtonSmall onClick={assign}
-              variant='secondary'>Assign</ButtonSmall>
-          </Box>
-        </Flex>
-      </>
+            </Flex>
+          </GridItem>
+        )}
+        <GridItem area='assign'>
+          <Flex height='100%' alignItems='center' justifyContent='flex-end'>
+            <ButtonSmall onClick={assign} variant='secondary'>
+              Assign
+            </ButtonSmall>
+          </Flex>
+        </GridItem>
+        <GridItem area='address'>
+          <LabelWithCopy
+            color='gray.3'
+            text={address}
+            textSize={13}
+            textVariant='b3'
+          />
+        </GridItem>
+      </UnassignedAccountHoverGrid>
     );
   };
 
@@ -294,7 +305,8 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
         mt='s'
         onMouseEnter={mouseEnter}
         onMouseLeave={mouseLeave}
-        px='s'>
+        px='s'
+      >
         <AccountViewGrid>
           <Box onClick={selectAccount} style={{ cursor: 'pointer' }}>
             <Flex height='100%'>
@@ -342,16 +354,25 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
 
 const AccountViewGrid = styled.div`
   display: grid;
-  grid-template-areas: "avatar account-details options";
+  grid-template-areas: 'avatar account-details options';
   gap: 10px;
+  grid-template-columns: 35px 200px 35px;
 `;
 
 const AccountDetailsGrid = styled.div`
   display: grid;
   grid-template-areas:
-    "name-edit name-edit name-edit name-edit"
-    "name      name      name      type"
-    "address   address   balance   balance";
+    'name-edit name-edit name-edit name-edit'
+    'name      name      name      type'
+    'address   address   balance   balance';
+`;
+
+const UnassignedAccountHoverGrid = styled.div`
+  display: grid;
+  grid-template-areas:
+    'name-edit name-edit name-edit name-edit'
+    'name      name      name      assign'
+    'address   address   address   assign';
 `;
 
 const GridItem = styled.div<{ area: string }>`

--- a/packages/ui/src/Popup/Accounts/AccountView.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountView.tsx
@@ -127,7 +127,8 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
       <AccountDetailsGrid>
         {isEditing && (
           <GridItem area='name-edit'>
-            <Flex alignItems='end' flexDirection='row'>
+            <Flex alignItems='end'
+              flexDirection='row'>
               <TextInput
                 defaultValue={name}
                 onChange={handleNameChange}
@@ -163,8 +164,8 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
               onMouseLeave={nameMouseLeave}
             >
               <TextOverflowEllipsis
-                maxWidth='100px'
                 color='gray.1'
+                maxWidth='100px'
                 variant='b2m'
               >
                 {name}
@@ -183,12 +184,14 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
           </GridItem>
         )}
         <GridItem area='type'>
-          <Flex height='100%' justifyContent='flex-end'>
+          <Flex height='100%'
+            justifyContent='flex-end'>
             {!isEditing && did && <AccountType keyType={keyType} />}
           </Flex>
         </GridItem>
         <GridItem area='address'>
-          <Flex height='100%' alignItems='flex-end'>
+          <Flex alignItems='flex-end'
+            height='100%'>
             <LabelWithCopy
               color='gray.3'
               text={address}
@@ -198,8 +201,11 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
           </Flex>
         </GridItem>
         <GridItem area='balance'>
-          <Flex height='100%' justifyContent='flex-end'>
-            <Text color='gray.1' variant='b3' style={{ whiteSpace: 'nowrap' }}>
+          <Flex height='100%'
+            justifyContent='flex-end'>
+            <Text color='gray.1'
+              style={{ whiteSpace: 'nowrap' }}
+              variant='b3'>
               {formatters.formatAmount(new BigNumber(balance || 0), 2, true)}{' '}
               POLYX
             </Text>
@@ -259,8 +265,8 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
               onMouseLeave={nameMouseLeave}
             >
               <TextOverflowEllipsis
-                maxWidth='100px'
                 color='gray.1'
+                maxWidth='100px'
                 variant='b2m'
               >
                 {name}
@@ -279,8 +285,11 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
           </GridItem>
         )}
         <GridItem area='assign'>
-          <Flex height='100%' alignItems='center' justifyContent='flex-end'>
-            <ButtonSmall onClick={assign} variant='secondary'>
+          <Flex alignItems='center'
+            height='100%'
+            justifyContent='flex-end'>
+            <ButtonSmall onClick={assign}
+              variant='secondary'>
               Assign
             </ButtonSmall>
           </Flex>
@@ -308,7 +317,8 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
         px='s'
       >
         <AccountViewGrid>
-          <Box onClick={selectAccount} style={{ cursor: 'pointer' }}>
+          <Box onClick={selectAccount}
+            style={{ cursor: 'pointer' }}>
             <Flex height='100%'>
               <Box
                 backgroundColor='brandLightest'
@@ -317,8 +327,10 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
                 px='2'
                 width={32}
               >
-                <Flex justifyContent='center' pt='xxs'>
-                  <Text color='brandMain' variant='b2m'>
+                <Flex justifyContent='center'
+                  pt='xxs'>
+                  <Text color='brandMain'
+                    variant='b2m'>
                     {name?.substr(0, 1)}
                   </Text>
                 </Flex>

--- a/packages/ui/src/Popup/Accounts/AccountView.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountView.tsx
@@ -159,8 +159,8 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
         {!isEditing && (
           <GridItem area='name'>
             <Flex
-              minWidth='100px'
               flexDirection='row'
+              minWidth='100px'
               onMouseEnter={nameMouseEnter}
               onMouseLeave={nameMouseLeave}
             >

--- a/packages/ui/src/Popup/Accounts/AccountView.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountView.tsx
@@ -159,6 +159,7 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
         {!isEditing && (
           <GridItem area='name'>
             <Flex
+              width='100px'
               flexDirection='row'
               onMouseEnter={nameMouseEnter}
               onMouseLeave={nameMouseLeave}

--- a/packages/ui/src/Popup/Accounts/AccountView.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountView.tsx
@@ -159,7 +159,7 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
         {!isEditing && (
           <GridItem area='name'>
             <Flex
-              width='100px'
+              minWidth='100px'
               flexDirection='row'
               onMouseEnter={nameMouseEnter}
               onMouseLeave={nameMouseLeave}

--- a/packages/ui/src/Popup/Accounts/AccountView.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountView.tsx
@@ -4,6 +4,7 @@ import { SvgCheck, SvgDotsVertical, SvgPencilOutline, SvgWindowClose } from '@po
 import BigNumber from 'bignumber.js';
 import React, { FC, useContext, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import styled from 'styled-components'
 
 import { AccountType, ActionContext, PolymeshContext } from '../../components';
 import { editAccount, setPolySelectedAccount } from '../../messaging';
@@ -123,75 +124,74 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
 
   const renderAccountInfo = () => {
     return (
-      <>
-        <Flex
-          flexDirection='row'
-          justifyContent='space-between'
-        >
-          <Flex flexDirection='row'>
-            {isEditing && (
-              <Flex alignItems='center'
-                flexDirection='row'>
-                <TextInput defaultValue={name}
-                  onChange={handleNameChange}
-                  tight
-                  value={newName} />
-                <Box ml='xs'>
-                  <Icon Asset={SvgCheck}
-                    color='gray.2'
-                    height={16}
-                    onClick={save}
-                    width={16} />
-                </Box>
-                <Box ml='xs'>
-                  <Icon Asset={SvgWindowClose}
-                    color='gray.2'
-                    height={16}
-                    onClick={cancelEditing}
-                    width={16} />
-                </Box>
+      <AccountDetailsGrid>
+        {isEditing && (
+          <GridItem area='name-edit'>
+            <Flex alignItems='end'
+              flexDirection='row'>
+              <TextInput defaultValue={name}
+                onChange={handleNameChange}
+                tight
+                value={newName} />
+              <Box ml='xs'>
+                <Icon Asset={SvgCheck}
+                  color='gray.2'
+                  height={16}
+                  onClick={save}
+                  width={16} />
+              </Box>
+              <Box ml='xs'>
+                <Icon Asset={SvgWindowClose}
+                  color='gray.2'
+                  height={16}
+                  onClick={cancelEditing}
+                  width={16} />
+              </Box>
+            </Flex>
+          </GridItem>
+        )}
+        {!isEditing && (
+          <GridItem area='name'>
+            <Flex alignItems=''
+              flexDirection='row'
+              onMouseEnter={nameMouseEnter}
+              onMouseLeave={nameMouseLeave}>
+              <TextOverflowEllipsis width="100px" color='gray.1' variant='b2m'>
+                {name}
+              </TextOverflowEllipsis>
+              <Flex ml='xs'>
+                <Icon Asset={SvgPencilOutline}
+                  color={nameHover ? 'gray.2' : 'gray.5'}
+                  height={16}
+                  onClick={editName}
+                  style={{ cursor: 'pointer' }}
+                  width={16} />
               </Flex>
-            )}
-            {!isEditing && (
-              <Flex alignItems='center'
-                flexDirection='row'
-                onMouseEnter={nameMouseEnter}
-                onMouseLeave={nameMouseLeave}>
-                <TextOverflowEllipsis color='gray.1' width="100px">
-                  {name}
-                </TextOverflowEllipsis>
-                <Flex ml='xs'>
-                  <Icon Asset={SvgPencilOutline}
-                    color={nameHover ? 'gray.2' : 'gray.5'}
-                    height={16}
-                    onClick={editName}
-                    style={{ cursor: 'pointer' }}
-                    width={16} />
-                </Flex>
-              </Flex>
-            )}
-            <Box ml='s'>
-              {!isEditing && did && <AccountType keyType={keyType} />}
-            </Box>
+            </Flex>
+          </GridItem>
+        )}
+        <GridItem area='type'>
+          <Flex height='100%' justifyContent='flex-end'>
+            {!isEditing && did && <AccountType keyType={keyType} />}
           </Flex>
-        </Flex>
-        <Flex
-          flexDirection='row'
-          justifyContent='space-between'
-        >
-          <LabelWithCopy color='gray.3'
-            text={address}
-            textSize={13}
-            textVariant='b3'
-          />
-          <Box>
-            <Text color='gray.1'
-              variant='b3'>
+        </GridItem>
+        <GridItem area='address'>
+          <Flex height='100%' alignItems='flex-end'>
+            <LabelWithCopy color='gray.3'
+              text={address}
+              textSize={13}
+              textVariant='b3'
+            />
+          </Flex>
+        </GridItem>
+        <GridItem area='balance'>
+          <Flex height='100%' justifyContent='flex-end'>
+            <Text color='gray.1' variant='b3' style={{ whiteSpace: 'nowrap' }}>
               {formatters.formatAmount(new BigNumber(balance || 0), 2, true)} POLYX
             </Text>
-          </Box>
-        </Flex>
-      </>
+          </Flex>
+        </GridItem>
+      </AccountDetailsGrid>
     );
   };
 
@@ -276,31 +276,32 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
         onMouseEnter={mouseEnter}
         onMouseLeave={mouseLeave}
         px='s'>
-        <Flex justifyContent='space-between'>
+        <AccountViewGrid>
           <Box onClick={selectAccount}
             style={{ cursor: 'pointer' }}>
-            <Box
-              backgroundColor='brandLightest'
-              borderRadius='50%'
-              height={32}
-              px='2'
-              width={32}
-            >
-              <Flex justifyContent='center'
-                pt='xxs'>
-                <Text color='brandMain'
-                  variant='b2m'>{name?.substr(0, 1)}</Text>
-              </Flex>
-            </Box>
+            <Flex height="100%">
+              <Box
+                backgroundColor='brandLightest'
+                borderRadius='50%'
+                height={32}
+                px='2'
+                width={32}
+              >
+                <Flex justifyContent='center'
+                  pt='xxs'>
+                  <Text color='brandMain'
+                    variant='b2m'>{name?.substr(0, 1)}</Text>
+                </Flex>
+              </Box>
+            </Flex>
           </Box>
-          <Box ml='s'
-            width='100%'>
+          <Box>
             {(!hover || did) && renderAccountInfo()}
             {(hover && !did) && renderHoverAccountInfo()}
           </Box>
           <Flex alignItems='flex-end'
             flexDirection='column'
-            justifyContent='flex-end'>
+            justifyContent='space-around'>
             <Box width={24}>
               {
                 isSelected &&
@@ -314,8 +315,26 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
               {renderActionsMenuButton(address)}
             </Box>
           </Flex>
-        </Flex>
+        </AccountViewGrid>
       </Box>
     </>
   );
 };
+
+const AccountViewGrid = styled.div`
+  display: grid;
+  grid-template-areas: "avatar account-details options";
+  gap: 10px;
+`;
+
+const AccountDetailsGrid = styled.div`
+  display: grid;
+  grid-template-areas:
+    "name-edit name-edit name-edit name-edit"
+    "name      name      name      type"
+    "address   address   balance   balance";
+`;
+
+const GridItem = styled.div<{ area: string }>`
+  grid-area: ${(props) => props.area};
+`;

--- a/packages/ui/src/Popup/Accounts/AccountView.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountView.tsx
@@ -7,7 +7,7 @@ import { useHistory } from 'react-router-dom';
 
 import { AccountType, ActionContext, PolymeshContext } from '../../components';
 import { editAccount, setPolySelectedAccount } from '../../messaging';
-import { Box, ButtonSmall, ContextMenuTrigger, Flex, Icon, LabelWithCopy, Menu, MenuItem, Text, TextInput } from '../../ui';
+import { Box, ButtonSmall, ContextMenuTrigger, Flex, Icon, LabelWithCopy, Menu, MenuItem, Text, TextInput, TextOverflowEllipsis } from '../../ui';
 import { formatters } from '../../util';
 
 export interface Props {
@@ -157,10 +157,9 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
                 flexDirection='row'
                 onMouseEnter={nameMouseEnter}
                 onMouseLeave={nameMouseLeave}>
-                <Text color='gray.1'
-                  variant='b2m'>
+                <TextOverflowEllipsis color='gray.1' width="100px">
                   {name}
-                </Text>
+                </TextOverflowEllipsis>
                 <Flex ml='xs'>
                   <Icon Asset={SvgPencilOutline}
                     color={nameHover ? 'gray.2' : 'gray.5'}

--- a/packages/ui/src/Popup/Accounts/AccountView.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountView.tsx
@@ -127,45 +127,58 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
       <AccountDetailsGrid>
         {isEditing && (
           <GridItem area='name-edit'>
-            <Flex alignItems='end'
-              flexDirection='row'>
-              <TextInput defaultValue={name}
+            <Flex alignItems='end' flexDirection='row'>
+              <TextInput
+                defaultValue={name}
                 onChange={handleNameChange}
                 tight
-                value={newName} />
+                value={newName}
+              />
               <Box ml='xs'>
-                <Icon Asset={SvgCheck}
+                <Icon
+                  Asset={SvgCheck}
                   color='gray.2'
                   height={16}
                   onClick={save}
-                  width={16} />
+                  width={16}
+                />
               </Box>
               <Box ml='xs'>
-                <Icon Asset={SvgWindowClose}
+                <Icon
+                  Asset={SvgWindowClose}
                   color='gray.2'
                   height={16}
                   onClick={cancelEditing}
-                  width={16} />
+                  width={16}
+                />
               </Box>
             </Flex>
           </GridItem>
         )}
         {!isEditing && (
           <GridItem area='name'>
-            <Flex alignItems=''
+            <Flex
+              alignItems=''
               flexDirection='row'
               onMouseEnter={nameMouseEnter}
-              onMouseLeave={nameMouseLeave}>
-              <TextOverflowEllipsis width="100px" color='gray.1' variant='b2m'>
+              onMouseLeave={nameMouseLeave}
+            >
+              <TextOverflowEllipsis
+                width='100px'
+                color='gray.1'
+                variant='b2m'
+              >
                 {name}
               </TextOverflowEllipsis>
               <Flex ml='xs'>
-                <Icon Asset={SvgPencilOutline}
+                <Icon
+                  Asset={SvgPencilOutline}
                   color={nameHover ? 'gray.2' : 'gray.5'}
                   height={16}
                   onClick={editName}
                   style={{ cursor: 'pointer' }}
-                  width={16} />
+                  width={16}
+                />
               </Flex>
             </Flex>
           </GridItem>
@@ -177,7 +190,8 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
         </GridItem>
         <GridItem area='address'>
           <Flex height='100%' alignItems='flex-end'>
-            <LabelWithCopy color='gray.3'
+            <LabelWithCopy
+              color='gray.3'
               text={address}
               textSize={13}
               textVariant='b3'
@@ -186,8 +200,13 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
         </GridItem>
         <GridItem area='balance'>
           <Flex height='100%' justifyContent='flex-end'>
-            <Text color='gray.1' variant='b3' style={{ whiteSpace: 'nowrap' }}>
-              {formatters.formatAmount(new BigNumber(balance || 0), 2, true)} POLYX
+            <Text
+              color='gray.1'
+              variant='b3'
+              style={{ whiteSpace: 'nowrap' }}
+            >
+              {formatters.formatAmount(new BigNumber(balance || 0), 2, true)}{' '}
+              POLYX
             </Text>
           </Flex>
         </GridItem>
@@ -277,9 +296,8 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
         onMouseLeave={mouseLeave}
         px='s'>
         <AccountViewGrid>
-          <Box onClick={selectAccount}
-            style={{ cursor: 'pointer' }}>
-            <Flex height="100%">
+          <Box onClick={selectAccount} style={{ cursor: 'pointer' }}>
+            <Flex height='100%'>
               <Box
                 backgroundColor='brandLightest'
                 borderRadius='50%'
@@ -287,33 +305,34 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
                 px='2'
                 width={32}
               >
-                <Flex justifyContent='center'
-                  pt='xxs'>
-                  <Text color='brandMain'
-                    variant='b2m'>{name?.substr(0, 1)}</Text>
+                <Flex justifyContent='center' pt='xxs'>
+                  <Text color='brandMain' variant='b2m'>
+                    {name?.substr(0, 1)}
+                  </Text>
                 </Flex>
               </Box>
             </Flex>
           </Box>
           <Box>
             {(!hover || did) && renderAccountInfo()}
-            {(hover && !did) && renderHoverAccountInfo()}
+            {hover && !did && renderHoverAccountInfo()}
           </Box>
-          <Flex alignItems='flex-end'
+          <Flex
+            alignItems='flex-end'
             flexDirection='column'
-            justifyContent='space-around'>
+            justifyContent='space-around'
+          >
             <Box width={24}>
-              {
-                isSelected &&
-                  <Icon Asset={SvgCheck}
-                    color='brandMain'
-                    height={24}
-                    width={24} />
-              }
+              {isSelected && (
+                <Icon
+                  Asset={SvgCheck}
+                  color='brandMain'
+                  height={24}
+                  width={24}
+                />
+              )}
             </Box>
-            <Box>
-              {renderActionsMenuButton(address)}
-            </Box>
+            <Box>{renderActionsMenuButton(address)}</Box>
           </Flex>
         </AccountViewGrid>
       </Box>

--- a/packages/ui/src/Popup/Accounts/AccountsHeader.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountsHeader.tsx
@@ -7,7 +7,7 @@ import BigNumber from 'bignumber.js';
 import React, { FC, useContext, useState } from 'react';
 import { useHistory } from 'react-router';
 
-import { Box, Flex, Heading, Icon, LabelWithCopy, Text, TextEllipsis, TextInput } from '../../ui';
+import { Box, Flex, Heading, Icon, LabelWithCopy, Text, TextEllipsis, TextInput, TextOverflowEllipsis } from '../../ui';
 import { formatters } from '../../util';
 
 export interface Props {
@@ -46,17 +46,16 @@ export const AccountsHeader: FC<Props> = ({ account, details = true }) => {
   };
 
   const saveAlias = async () => {
-    account && account.did && network && await renameIdentity(network as NetworkName, account.did, newAlias);
+    account && account.did && network && (await renameIdentity(network as NetworkName, account.did, newAlias));
     stopEdit();
     onAction();
   };
 
   return (
     <>
-      {
-        account?.did &&
+      {account?.did && (
         <>
-          {!editing &&
+          {!editing && (
             <Flex alignItems='center'
               mb='xs'
               onMouseEnter={mouseEnter}
@@ -65,22 +64,23 @@ export const AccountsHeader: FC<Props> = ({ account, details = true }) => {
                 variant='b1m'>
                 {account.didAlias ? formatters.toShortAddress(account.didAlias, { size: 30 }) : '[Your Polymesh ID]'}
               </Text>
-              {hover &&
+              {hover && (
                 <Flex ml='xs'>
-                  <Icon Asset={SvgPencilOutline}
+                  <Icon
+                    Asset={SvgPencilOutline}
                     color='gray.0'
                     height={16}
                     onClick={startEdit}
                     style={{ cursor: 'pointer' }}
-                    width={16} />
+                    width={16}
+                  />
                 </Flex>
-              }
+              )}
             </Flex>
-          }
-          {editing &&
+          )}
+          {editing && (
             <Flex mb='xs'>
-              <TextInput
-                onChange={handleAliasChange}
+              <TextInput onChange={handleAliasChange}
                 tight
                 value={newAlias} />
               <Box onClick={saveAlias}
@@ -98,7 +98,7 @@ export const AccountsHeader: FC<Props> = ({ account, details = true }) => {
                   width={24} />
               </Box>
             </Flex>
-          }
+          )}
           <Box bg='brandLightest'
             borderRadius='2'
             py='xs'>
@@ -118,20 +118,22 @@ export const AccountsHeader: FC<Props> = ({ account, details = true }) => {
             )}
           </Box>
         </>
-      }
-      {
-        !account?.did &&
-    <Text color='brandLighter'
-      variant='b2m'>Unassigned key</Text>
-      }
+      )}
+      {!account?.did && (
+        <Text color='brandLighter'
+          variant='b2m'>
+          Unassigned key
+        </Text>
+      )}
       <Flex alignItems='center'
         flexDirection='row'
         mt='s'>
         <Box>
-          <Text color='gray.0'
+          <TextOverflowEllipsis color='gray.0'
+            maxWidth='206px'
             variant='b1m'>
             {account?.name}
-          </Text>
+          </TextOverflowEllipsis>
         </Box>
         <Box ml='s'>
           {account?.did && <AccountType keyType={account?.keyType}
@@ -139,7 +141,8 @@ export const AccountsHeader: FC<Props> = ({ account, details = true }) => {
         </Box>
       </Flex>
       <Flex>
-        <LabelWithCopy color='brandLightest'
+        <LabelWithCopy
+          color='brandLightest'
           hoverColor='brandLighter'
           text={account?.address || ''}
           textSize={30}
@@ -160,23 +163,27 @@ export const AccountsHeader: FC<Props> = ({ account, details = true }) => {
           </Text>
         </Box>
       </Flex>
-      {details && <Box mt='m'>
-        <Box borderColor='gray.0'
-          borderRadius='3'
-          borderStyle='solid'
-          borderWidth={2}
-          onClick={showAccountDetails}
-          style={{ cursor: 'pointer' }}>
-          <Flex alignItems='center'
-            height={32}
-            justifyContent='center'>
-            <Text color='gray.0'
-              variant='b2m'>
-              View details
-            </Text>
-          </Flex>
+      {details && (
+        <Box mt='m'>
+          <Box
+            borderColor='gray.0'
+            borderRadius='3'
+            borderStyle='solid'
+            borderWidth={2}
+            onClick={showAccountDetails}
+            style={{ cursor: 'pointer' }}
+          >
+            <Flex alignItems='center'
+              height={32}
+              justifyContent='center'>
+              <Text color='gray.0'
+                variant='b2m'>
+                View details
+              </Text>
+            </Flex>
+          </Box>
         </Box>
-      </Box> }
+      )}
     </>
   );
 };

--- a/packages/ui/src/ui/TextOverflowEllipsis/TextOverflowEllipsis.tsx
+++ b/packages/ui/src/ui/TextOverflowEllipsis/TextOverflowEllipsis.tsx
@@ -1,0 +1,21 @@
+import React, { ComponentProps, PropsWithChildren } from 'react';
+import styled from 'styled-components';
+import { Text } from '@polymathnetwork/extension-ui/ui';
+
+export const EllipsiedText = styled(Text)`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+type Props = PropsWithChildren<{ width: number | string }> & ComponentProps<typeof Text>;
+
+export function TextOverflowEllipsis(props: Props) {
+  const { children, ...textProps } = props;
+
+  return (
+    <EllipsiedText {...textProps}>
+      {children}
+    </EllipsiedText>
+  );
+}

--- a/packages/ui/src/ui/TextOverflowEllipsis/TextOverflowEllipsis.tsx
+++ b/packages/ui/src/ui/TextOverflowEllipsis/TextOverflowEllipsis.tsx
@@ -13,9 +13,5 @@ type Props = PropsWithChildren<{ width: number | string }> & ComponentProps<type
 export function TextOverflowEllipsis(props: Props) {
   const { children, ...textProps } = props;
 
-  return (
-    <EllipsiedText {...textProps}>
-      {children}
-    </EllipsiedText>
-  );
+  return <EllipsiedText {...textProps}>{children}</EllipsiedText>;
 }

--- a/packages/ui/src/ui/TextOverflowEllipsis/TextOverflowEllipsis.tsx
+++ b/packages/ui/src/ui/TextOverflowEllipsis/TextOverflowEllipsis.tsx
@@ -8,7 +8,7 @@ export const EllipsiedText = styled(Text)`
   text-overflow: ellipsis;
 `;
 
-type Props = PropsWithChildren<{ width: number | string }> &
+type Props = PropsWithChildren<{ maxWidth: number | string }> &
   ComponentProps<typeof Text>;
 
 export function TextOverflowEllipsis(props: Props) {

--- a/packages/ui/src/ui/TextOverflowEllipsis/TextOverflowEllipsis.tsx
+++ b/packages/ui/src/ui/TextOverflowEllipsis/TextOverflowEllipsis.tsx
@@ -1,18 +1,16 @@
 import { Text } from '@polymathnetwork/extension-ui/ui';
-import React, { ComponentProps, PropsWithChildren } from 'react';
+import React, { ComponentProps, FC } from 'react';
 import styled from 'styled-components';
 
-export const EllipsiedText = styled(Text)`
+export const EllipsiedText = styled(Text)<{ maxWidth: number | string }>`
+  display: inline-block;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 `;
 
-type Props = PropsWithChildren<{ maxWidth: number | string }> &
-ComponentProps<typeof Text>;
+type Props = { maxWidth: number | string } & ComponentProps<typeof Text>;
 
-export function TextOverflowEllipsis (props: Props) {
-  const { children, ...textProps } = props;
-
-  return <EllipsiedText {...textProps}>{children}</EllipsiedText>;
-}
+export const TextOverflowEllipsis: FC<Props> = ({ children, ...textProps }) => (
+  <EllipsiedText {...textProps}>{children}</EllipsiedText>
+);

--- a/packages/ui/src/ui/TextOverflowEllipsis/TextOverflowEllipsis.tsx
+++ b/packages/ui/src/ui/TextOverflowEllipsis/TextOverflowEllipsis.tsx
@@ -8,7 +8,8 @@ export const EllipsiedText = styled(Text)`
   text-overflow: ellipsis;
 `;
 
-type Props = PropsWithChildren<{ width: number | string }> & ComponentProps<typeof Text>;
+type Props = PropsWithChildren<{ width: number | string }> &
+  ComponentProps<typeof Text>;
 
 export function TextOverflowEllipsis(props: Props) {
   const { children, ...textProps } = props;

--- a/packages/ui/src/ui/TextOverflowEllipsis/TextOverflowEllipsis.tsx
+++ b/packages/ui/src/ui/TextOverflowEllipsis/TextOverflowEllipsis.tsx
@@ -1,6 +1,6 @@
+import { Text } from '@polymathnetwork/extension-ui/ui';
 import React, { ComponentProps, PropsWithChildren } from 'react';
 import styled from 'styled-components';
-import { Text } from '@polymathnetwork/extension-ui/ui';
 
 export const EllipsiedText = styled(Text)`
   white-space: nowrap;
@@ -9,9 +9,9 @@ export const EllipsiedText = styled(Text)`
 `;
 
 type Props = PropsWithChildren<{ maxWidth: number | string }> &
-  ComponentProps<typeof Text>;
+ComponentProps<typeof Text>;
 
-export function TextOverflowEllipsis(props: Props) {
+export function TextOverflowEllipsis (props: Props) {
   const { children, ...textProps } = props;
 
   return <EllipsiedText {...textProps}>{children}</EllipsiedText>;

--- a/packages/ui/src/ui/TextOverflowEllipsis/index.ts
+++ b/packages/ui/src/ui/TextOverflowEllipsis/index.ts
@@ -1,0 +1,1 @@
+export { TextOverflowEllipsis } from './TextOverflowEllipsis';

--- a/packages/ui/src/ui/index.ts
+++ b/packages/ui/src/ui/index.ts
@@ -24,3 +24,4 @@ export { Loading } from './Loading';
 export { Hr } from './Hr';
 export { GrowingButton } from './GrowingButton';
 export { ExpandableDetails } from './ExpandableDetails';
+export { TextOverflowEllipsis } from './TextOverflowEllipsis';


### PR DESCRIPTION
Demo: https://polymath.atlassian.net/browse/WAL-122?focusedCommentId=15747

✅ Badge should be vertically aligned with balance display as well, while not overlapping with the selection checkmark.

Used CSS grids + flex to define the layouts for account details + hover state for unassigned accounts.

✅ Names should have max width and then elipsises. 

Created a new `TextOverflowEllipsis` component which requires a `maxWidth`; if text inside overflows it will use "..." as the last characters (CSS only).

⛔️ (optional) Preferably, both secondary and primary badged should have the same width.

I thought it looked nice as it is, I experiemented with uniform badge widths, I actually thought the current way is fine/better in comparison. For refernce, this is how it looks with uniform widths:

![image](https://user-images.githubusercontent.com/7417976/108530710-e4469a00-72a3-11eb-80fa-c5dd6f50a886.png)

Let me know if I should go ahead with this change!