### PR TITLE
fix: add background color to account card to make it not-transparent (WAL-89)

### DIFF
--- a/packages/ui/src/Popup/Accounts/AccountsContainer.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountsContainer.tsx
@@ -137,7 +137,8 @@ export const AccountsContainer: FC<Props> = ({ accounts, did, headerColor, selec
   };
 
   return (
-    <Box borderRadius='2'
+    <Box bg='white'
+      borderRadius='2'
       boxShadow='3'
       m='s'
       pb='xs'


### PR DESCRIPTION
I was tinkering around with this bug, and then I realized the reason for this "illusion" is because the account cards are _transparent_, i.e. the shadows are showing _through_ them not on top of them 😂

Simply adding a background color (white) solves the issue!

Example:
![image](https://user-images.githubusercontent.com/7417976/108864187-f5531c00-75bf-11eb-896f-1cfca8c504ea.png)
