### PR TITLE
feat: update create/restore account UI (WAL-112)

### DIFF
--- a/packages/ui/src/components/AccountDetails.tsx
+++ b/packages/ui/src/components/AccountDetails.tsx
@@ -70,26 +70,22 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
   const renderNewAccountForm = () => (
     <>
       <Box mt='m'>
+        <Text color='gray.1'
+          variant='b2m'>
+          Account name
+        </Text>
+      </Box>
+      <TextInput inputRef={register({ required: true })}
+        name='accountName'
+        placeholder='Enter account name' />
+      {errors?.accountName &&
         <Box>
-          <Text color='gray.1'
-            variant='b2m'>
-            Account name
+          <Text color='alert'
+            variant='b3'>
+            {(errors.accountName).type === 'required' && 'Required field'}
           </Text>
         </Box>
-        <Box>
-          <TextInput inputRef={register({ required: true })}
-            name='accountName'
-            placeholder='Enter account name' />
-          {errors?.accountName &&
-            <Box>
-              <Text color='alert'
-                variant='b3'>
-                {(errors.accountName).type === 'required' && 'Required field'}
-              </Text>
-            </Box>
-          }
-        </Box>
-      </Box>
+      }
       <Box mt='m'>
         <Text color='gray.2'
           variant='b2'>Please enter a new wallet password below to complete account creation.</Text>
@@ -107,44 +103,36 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
           Current wallet account
         </Text>
       </Box>
-      <Box>
-        <Text color='gray.1'
-          variant='b1'>
-          {selectedAccount && toShortAddress(selectedAccount, { size: 33 })}
-        </Text>
-      </Box>
-      <Box>
-        <Password label='Password'
-          placeholder='Enter your current wallet password' />
-      </Box>
+      <Text color='gray.1'
+        variant='b1'>
+        {selectedAccount && toShortAddress(selectedAccount, { size: 33 })}
+      </Text>
+      <Password label='Password'
+        placeholder='Enter your current wallet password' />
       <Box my='m'>
         <Hr />
       </Box>
-      <Box>
-        <Text color='gray.2'
-          variant='b2'>
-          Please enter a new account name to complete restore with your recovery phrase.
-        </Text>
-      </Box>
+      <Text color='gray.2'
+        variant='b2'>
+        Please enter a new account name to complete restore with your recovery phrase.
+      </Text>
       <Box mt='m'>
         <Text color='gray.1'
           variant='b2m'>
           Account name
         </Text>
       </Box>
-      <Box>
-        <TextInput inputRef={register({ required: true })}
-          name='accountName'
-          placeholder='Enter account name' />
-        {errors?.accountName &&
-          <Box>
-            <Text color='alert'
-              variant='b3'>
-              {(errors.accountName).type === 'required' && 'Required field'}
-            </Text>
-          </Box>
-        }
-      </Box>
+      <TextInput inputRef={register({ required: true })}
+        name='accountName'
+        placeholder='Enter account name' />
+      {errors?.accountName &&
+        <Box>
+          <Text color='alert'
+            variant='b3'>
+            {(errors.accountName).type === 'required' && 'Required field'}
+          </Text>
+        </Box>
+      }
     </>
   );
 
@@ -158,35 +146,6 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
           <form id='accountForm'
             onSubmit={handleSubmit(onSubmit)}>
             {oneAddress ? renderAccountForm() : renderNewAccountForm()}
-            {/* <Box mt='m'>
-              <Box>
-                <Text color='gray.1'
-                  variant='b2m'>
-                  Account name
-                </Text>
-              </Box>
-              <Box>
-                <TextInput inputRef={register({ required: true })}
-                  name='accountName'
-                  placeholder='Enter account name' />
-                {errors?.accountName &&
-                  <Box>
-                    <Text color='alert'
-                      variant='b3'>
-                      {(errors.accountName).type === 'required' && 'Required field'}
-                    </Text>
-                  </Box>
-                }
-              </Box>
-            </Box>
-            {!oneAddress &&
-              <Box mt='m'>
-                <Text color='gray.2'
-                  variant='b2'>Please enter a new wallet password below to complete account creation.</Text>
-              </Box>
-            }
-            <Password label={oneAddress ? 'Wallet password' : 'Password'}
-              withConfirm={!oneAddress} /> */}
           </form>
         </FormProvider>
       </Box>

--- a/packages/ui/src/components/AccountDetails.tsx
+++ b/packages/ui/src/components/AccountDetails.tsx
@@ -114,7 +114,8 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
         </Text>
       </Box>
       <Box>
-        <Password label='Password' />
+        <Password label='Password'
+          placeholder='Enter your current wallet password' />
       </Box>
       <Box my='m'>
         <Hr />

--- a/packages/ui/src/components/AccountDetails.tsx
+++ b/packages/ui/src/components/AccountDetails.tsx
@@ -1,10 +1,11 @@
 import { SvgAccountCardDetailsOutline, SvgArrowLeft } from '@polymathnetwork/extension-ui/assets/images/icons';
 import { ActivityContext, Password } from '@polymathnetwork/extension-ui/components';
 import { validateAccount } from '@polymathnetwork/extension-ui/messaging';
-import { Box, Button, Flex, Header, Icon, Text, TextInput } from '@polymathnetwork/extension-ui/ui';
+import { Box, Button, Flex, Header, Hr, Icon, Text, TextInput } from '@polymathnetwork/extension-ui/ui';
 import React, { FC, useContext, useMemo } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
+import { toShortAddress } from '../util/formatters';
 import { PolymeshContext } from './contexts';
 
 export interface AccountInfo {
@@ -38,7 +39,7 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
   });
   const { errors, formState, getValues, handleSubmit, register, setError } = methods;
   const isBusy = useContext(ActivityContext);
-  const { polymeshAccounts } = useContext(PolymeshContext);
+  const { polymeshAccounts, selectedAccount } = useContext(PolymeshContext);
   // Get at least one address amongst user addresses. We will read that address
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const oneAddress = useMemo(() => polymeshAccounts && polymeshAccounts.length > 0 && polymeshAccounts[0].address, []);
@@ -66,6 +67,86 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
     Object.values(getValues()).filter((val) => val === '').length > 0 ||
     formState.isSubmitting;
 
+  const renderNewAccountForm = () => (
+    <>
+      <Box mt='m'>
+        <Box>
+          <Text color='gray.1'
+            variant='b2m'>
+            Account name
+          </Text>
+        </Box>
+        <Box>
+          <TextInput inputRef={register({ required: true })}
+            name='accountName'
+            placeholder='Enter account name' />
+          {errors?.accountName &&
+            <Box>
+              <Text color='alert'
+                variant='b3'>
+                {(errors.accountName).type === 'required' && 'Required field'}
+              </Text>
+            </Box>
+          }
+        </Box>
+      </Box>
+      <Box mt='m'>
+        <Text color='gray.2'
+          variant='b2'>Please enter a new wallet password below to complete account creation.</Text>
+      </Box>
+      <Password label={oneAddress ? 'Wallet password' : 'Password'}
+        withConfirm={!oneAddress} />
+    </>
+  );
+
+  const renderAccountForm = () => (
+    <>
+      <Box mt='m'>
+        <Text color='gray.2'
+          variant='b2m'>
+          Current wallet account
+        </Text>
+      </Box>
+      <Box>
+        <Text color='gray.1'
+          variant='b1'>
+          {selectedAccount && toShortAddress(selectedAccount, { size: 33 })}
+        </Text>
+      </Box>
+      <Box>
+        <Password label='Password' />
+      </Box>
+      <Box my='m'>
+        <Hr />
+      </Box>
+      <Box>
+        <Text color='gray.2'
+          variant='b2'>
+          Please enter a new account name to complete restore with your recovery phrase.
+        </Text>
+      </Box>
+      <Box mt='m'>
+        <Text color='gray.1'
+          variant='b2m'>
+          Account name
+        </Text>
+      </Box>
+      <Box>
+        <TextInput inputRef={register({ required: true })}
+          name='accountName'
+          placeholder='Enter account name' />
+        {errors?.accountName &&
+          <Box>
+            <Text color='alert'
+              variant='b3'>
+              {(errors.accountName).type === 'required' && 'Required field'}
+            </Text>
+          </Box>
+        }
+      </Box>
+    </>
+  );
+
   return (
     <>
       <Header headerText={headerText}
@@ -75,7 +156,8 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
         <FormProvider {...methods} >
           <form id='accountForm'
             onSubmit={handleSubmit(onSubmit)}>
-            <Box mt='m'>
+            {oneAddress ? renderAccountForm() : renderNewAccountForm()}
+            {/* <Box mt='m'>
               <Box>
                 <Text color='gray.1'
                   variant='b2m'>
@@ -103,7 +185,7 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
               </Box>
             }
             <Password label={oneAddress ? 'Wallet password' : 'Password'}
-              withConfirm={!oneAddress} />
+              withConfirm={!oneAddress} /> */}
           </form>
         </FormProvider>
       </Box>

--- a/packages/ui/src/components/AccountDetails.tsx
+++ b/packages/ui/src/components/AccountDetails.tsx
@@ -114,7 +114,7 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
       </Box>
       <Text color='gray.2'
         variant='b2'>
-        Please enter a new account name to complete restore with your recovery phrase.
+        Please enter a new account name to complete account restoration with your recovery phrase.
       </Text>
       <Box mt='m'>
         <Text color='gray.1'

--- a/packages/ui/src/components/AccountDetails.tsx
+++ b/packages/ui/src/components/AccountDetails.tsx
@@ -90,8 +90,8 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
         <Text color='gray.2'
           variant='b2'>Please enter a new wallet password below to complete account creation.</Text>
       </Box>
-      <Password label={oneAddress ? 'Wallet password' : 'Password'}
-        withConfirm={!oneAddress} />
+      <Password label='Password'
+        withConfirm />
     </>
   );
 
@@ -107,7 +107,7 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
         variant='b1'>
         {selectedAccount && toShortAddress(selectedAccount, { size: 33 })}
       </Text>
-      <Password label='Password'
+      <Password label='Wallet password'
         placeholder='Enter your current wallet password' />
       <Box my='m'>
         <Hr />

--- a/packages/ui/src/components/Password.tsx
+++ b/packages/ui/src/components/Password.tsx
@@ -10,7 +10,7 @@ export interface Props {
   placeholder?: string;
 }
 
-export const Password: FC<Props> = ({ confirmLabel, label, withConfirm, placeholder }) => {
+export const Password: FC<Props> = ({ confirmLabel, label, placeholder, withConfirm }) => {
   const { errors, getValues, register } = useFormContext();
 
   const validatePassword = (value: string) => {

--- a/packages/ui/src/components/Password.tsx
+++ b/packages/ui/src/components/Password.tsx
@@ -7,9 +7,10 @@ export interface Props {
   label: string;
   confirmLabel?: string;
   withConfirm?: boolean;
+  placeholder?: string;
 }
 
-export const Password: FC<Props> = ({ confirmLabel, label, withConfirm }) => {
+export const Password: FC<Props> = ({ confirmLabel, label, withConfirm, placeholder }) => {
   const { errors, getValues, register } = useFormContext();
 
   const validatePassword = (value: string) => {
@@ -30,7 +31,7 @@ export const Password: FC<Props> = ({ confirmLabel, label, withConfirm }) => {
         <Box>
           <TextInput inputRef={register({ required: true, minLength: 8 })}
             name='password'
-            placeholder='Enter 8 characters or more'
+            placeholder={placeholder || 'Enter 8 characters or more'}
             type='password' />
           {errors.password &&
             <Box>


### PR DESCRIPTION
The UI for creating or importing an account on the wallet, after an account has already been created, and the wallet password has been set:

<img src="https://user-images.githubusercontent.com/7417976/109064094-f36c8400-76b7-11eb-8cd7-bc78d027383c.png" width="328px" />


The UI for creating a new account on the wallet, when there are no existing accounts, looks the same as before:

<img src="https://user-images.githubusercontent.com/7417976/109064119-f9fafb80-76b7-11eb-966e-ca2cc9ede385.png" width="328px" />
