### PR TITLE
feat: wallet password UI clarification (WAL-112)

### DIFF
--- a/__tests__/wallet.spec.ts
+++ b/__tests__/wallet.spec.ts
@@ -68,7 +68,7 @@ describe('Wallet', () => {
         await (await page.waitForXPath('//textarea')).type(seed);
         await (await page.waitForXPath("//button[contains(., 'Continue')]")).click();
         await (await page.waitForXPath("//input[@placeholder='Enter account name']")).type(accountName);
-        await (await page.waitForXPath("//input[@placeholder='Enter 8 characters or more']")).type(accountPass);
+        await (await page.waitForXPath("//input[@placeholder='Enter 8 characters or more' or @placeholder='Enter your current wallet password']")).type(accountPass);
         await (await page.waitForXPath("//input[@placeholder='Confirm your password']")).type(accountPass);
         await (await page.waitForXPath("//button[contains(., 'Restore')]")).click();
       });

--- a/packages/ui/src/components/AccountDetails.tsx
+++ b/packages/ui/src/components/AccountDetails.tsx
@@ -92,7 +92,7 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
           </Flex>
           <Text color='gray.1'
             variant='b2m'>
-            Use your current wallet password to be able to add this account.
+            Enter your current wallet password in order to add this account.
           </Text>
         </Box>
         <FormProvider {...methods} >

--- a/packages/ui/src/components/AccountDetails.tsx
+++ b/packages/ui/src/components/AccountDetails.tsx
@@ -1,4 +1,4 @@
-import { SvgAccountCardDetailsOutline, SvgArrowLeft } from '@polymathnetwork/extension-ui/assets/images/icons';
+import { SvgAccountCardDetailsOutline, SvgAlertCircle, SvgArrowLeft } from '@polymathnetwork/extension-ui/assets/images/icons';
 import { ActivityContext, Password } from '@polymathnetwork/extension-ui/components';
 import { validateAccount } from '@polymathnetwork/extension-ui/messaging';
 import { Box, Button, Flex, Header, Icon, Text, TextInput } from '@polymathnetwork/extension-ui/ui';
@@ -72,6 +72,29 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
         iconAsset={SvgAccountCardDetailsOutline}>
       </Header>
       <Box mx='s'>
+        <Box borderColor='gray.4'
+          borderRadius={3}
+          borderStyle='solid'
+          borderWidth={2}
+          mt='s'
+          p='s'>
+          <Flex mb='xs'>
+            <Icon Asset={SvgAlertCircle}
+              color='warning'
+              height={20}
+              width={20} />
+            <Box ml='s'>
+              <Text color='warning'
+                variant='b2m'>
+                Attention
+              </Text>
+            </Box>
+          </Flex>
+          <Text color='gray.1'
+            variant='b2m'>
+            Use your current wallet password to be able to add this account.
+          </Text>
+        </Box>
         <FormProvider {...methods} >
           <form id='accountForm'
             onSubmit={handleSubmit(onSubmit)}>

--- a/packages/ui/src/components/AccountDetails.tsx
+++ b/packages/ui/src/components/AccountDetails.tsx
@@ -126,6 +126,7 @@ export const AccountDetails: FC<Props> = ({ defaultName, headerText, onBack, onC
               </Box>
             }
             <Password label={oneAddress ? 'Wallet password' : 'Password'}
+              placeholder='Enter your current wallet password'
               withConfirm={!oneAddress} />
           </form>
         </FormProvider>

--- a/packages/ui/src/components/Password.tsx
+++ b/packages/ui/src/components/Password.tsx
@@ -7,9 +7,10 @@ export interface Props {
   label: string;
   confirmLabel?: string;
   withConfirm?: boolean;
+  placeholder?: string;
 }
 
-export const Password: FC<Props> = ({ confirmLabel, label, withConfirm }) => {
+export const Password: FC<Props> = ({ confirmLabel, label, placeholder, withConfirm }) => {
   const { errors, getValues, register } = useFormContext();
 
   const validatePassword = (value: string) => {
@@ -30,7 +31,7 @@ export const Password: FC<Props> = ({ confirmLabel, label, withConfirm }) => {
         <Box>
           <TextInput inputRef={register({ required: true, minLength: 8 })}
             name='password'
-            placeholder='Enter 8 characters or more'
+            placeholder={placeholder || 'Enter 8 characters or more'}
             type='password' />
           {errors.password &&
             <Box>


### PR DESCRIPTION
- added information text to clarify using current wallet password; let me know if the copy should be changed!
- changed password input placeholder text to specify the current wallet password

Screenshot:
<img src="https://user-images.githubusercontent.com/7417976/109358240-707f3100-7851-11eb-9717-79552ffa006f.png" width="400px" />
