### PR TITLE
Better API management

### DIFF
--- a/packages/core/src/external/apiPromise/index.ts
+++ b/packages/core/src/external/apiPromise/index.ts
@@ -37,7 +37,7 @@ async function apiPromise (n: NetworkName, reinitialize = true): Promise<ApiProm
   // A) Wait until WS connection is successful.
   // B) A second later, if connection is not up, we throw an error.
   await new Promise<void>((resolve, reject) => {
-    const handle = setTimeout(() => reject(new Error(`Failed failed to connect to ${networkURLs[n]}`)), 1000);
+    const handle = setTimeout(() => reject(new Error(`Failed to connect to ${networkURLs[n]}`)), 1000);
 
     unsubscribe = provider.on('connected', () => {
       clearTimeout(handle);

--- a/packages/core/src/external/callDetails.ts
+++ b/packages/core/src/external/callDetails.ts
@@ -7,7 +7,7 @@ import { NetworkName } from '../types';
 import apiPromise from './apiPromise';
 
 async function callDetails (request: SignerPayloadJSON, network: NetworkName): Promise<ResponsePolyCallDetails> {
-  const api = await apiPromise(network);
+  const api = await apiPromise(network, false);
   let protocolFee = '0';
   let networkFee = '0';
 


### PR DESCRIPTION
@wahidrahim this PR addresses two issues:
- We initialize API object every time `apiPromise` function is called. The issue here is that api will end up being initialized _twice_ if user is signing a tx. Once when popup opens, and the other when `callDetails` is called. Adding `reinitialize` argument to `apiPromise`, ensures that we don't recreate API unnecessarily.
- When WS connection fails, because a node is down, or because the node url is bad, ApiPromise will retry the connection 1500 times, which means that user would look at an inifinite spinner. This PR attempts to catch those errors and display them.

To test WS connection issues, edit the url of Alcyone network in `src/core/constants`. You'll find that wallet will display an error when you switch network to Alcyone, but error should be removed when you switch to another network. 