### PR TITLE
UI fixes

### DIFF
--- a/packages/ui/src/Popup/ExportAccount/index.tsx
+++ b/packages/ui/src/Popup/ExportAccount/index.tsx
@@ -50,12 +50,11 @@ export const ExportAccount: FC = () => {
       <Header headerText='Export account'
         iconAsset={SvgOpenInNew}>
       </Header>
-      <Box pt='m'>
+      <Box p='s'>
         <Box borderColor='gray.4'
           borderRadius={3}
           borderStyle='solid'
           borderWidth={2}
-          m='xs'
           p='s'>
           <Flex>
             <Icon Asset={SvgAlertCircle}
@@ -74,22 +73,21 @@ export const ExportAccount: FC = () => {
             Please remember the password you enter below as you will need it to recover your account. You are exporting your account details as a JSON file. Keep this file safe and secured.
           </Text>
         </Box>
-      </Box>
-      <form id='passwordForm'
-        onSubmit={handleSubmit(onSubmit)}>
-        <Box mt='m'>
-          <Box>
-            <Text color='gray.1'
-              variant='b2m'>
+        <form id='passwordForm'
+          onSubmit={handleSubmit(onSubmit)}>
+          <Box mt='m'>
+            <Box>
+              <Text color='gray.1'
+                variant='b2m'>
               Wallet password
-            </Text>
-          </Box>
-          <Box>
-            <TextInput inputRef={register({ required: true, minLength: 8 })}
-              name='currentPassword'
-              placeholder='Enter your wallet password'
-              type='password' />
-            {errors.currentPassword &&
+              </Text>
+            </Box>
+            <Box>
+              <TextInput inputRef={register({ required: true, minLength: 8 })}
+                name='currentPassword'
+                placeholder='Enter your wallet password'
+                type='password' />
+              {errors.currentPassword &&
               <Box>
                 <Text color='alert'
                   variant='b3'>
@@ -98,22 +96,22 @@ export const ExportAccount: FC = () => {
                   {(errors.currentPassword).type === 'WrongPassword' && 'Invalid password'}
                 </Text>
               </Box>
-            }
+              }
+            </Box>
           </Box>
-        </Box>
-      </form>
-      <Flex flex={1}
-        flexDirection='column'
-        justifyContent='flex-end'
-        mb='s'
-        mx='xs'>
-        <Button busy={isBusy}
-          fluid
-          form='passwordForm'
-          type='submit'>
+        </form>
+        <Flex flex={1}
+          flexDirection='column'
+          justifyContent='flex-end'
+          my='s'>
+          <Button busy={isBusy}
+            fluid
+            form='passwordForm'
+            type='submit'>
           Export account
-        </Button>
-      </Flex>
+          </Button>
+        </Flex>
+      </Box>
     </>
   );
 };

--- a/packages/ui/src/Popup/ExportAccount/index.tsx
+++ b/packages/ui/src/Popup/ExportAccount/index.tsx
@@ -50,7 +50,10 @@ export const ExportAccount: FC = () => {
       <Header headerText='Export account'
         iconAsset={SvgOpenInNew}>
       </Header>
-      <Box p='s'>
+      <Flex alignItems='stretch'
+        flexDirection='column'
+        height='100%'
+        p='s'>
         <Box borderColor='gray.4'
           borderRadius={3}
           borderStyle='solid'
@@ -100,18 +103,15 @@ export const ExportAccount: FC = () => {
             </Box>
           </Box>
         </form>
-        <Flex flex={1}
-          flexDirection='column'
-          justifyContent='flex-end'
-          my='s'>
+        <Box mt='auto'>
           <Button busy={isBusy}
             fluid
             form='passwordForm'
             type='submit'>
-          Export account
+            Export account
           </Button>
-        </Flex>
-      </Box>
+        </Box>
+      </Flex>
     </>
   );
 };

--- a/packages/ui/src/Popup/ForgetAccount/index.tsx
+++ b/packages/ui/src/Popup/ForgetAccount/index.tsx
@@ -32,7 +32,8 @@ export const ForgetAccount: FC = () => {
       <Header headerText='Forget account'
         iconAsset={SvgFileLockOutline}>
       </Header>
-      <Flex flexDirection='column'
+      <Flex alignItems='stretch'
+        flexDirection='column'
         height='100%'
         p='s'>
         <Box borderColor='gray.4'
@@ -57,12 +58,11 @@ export const ForgetAccount: FC = () => {
             You are about to remove this account. Once removed, this account will not be accessible via this extension unless you re-add it via JSON file or seed phrase.
           </Text>
         </Box>
-        <Box mt='auto'
-          width='100%'>
+        <Box mt='auto'>
           <Button busy={isBusy}
             fluid
             onClick={onExport}>
-          Forget account
+            Forget account
           </Button>
         </Box>
       </Flex>

--- a/packages/ui/src/Popup/ForgetAccount/index.tsx
+++ b/packages/ui/src/Popup/ForgetAccount/index.tsx
@@ -32,41 +32,41 @@ export const ForgetAccount: FC = () => {
       <Header headerText='Forget account'
         iconAsset={SvgFileLockOutline}>
       </Header>
-      <Box pt='m'>
-        <Box borderColor='gray.4'
-          borderRadius={3}
-          borderStyle='solid'
-          borderWidth={2}
-          m='xs'
-          p='s'>
-          <Flex>
-            <Icon Asset={SvgAlertCircle}
-              color='alert'
-              height={20}
-              width={20} />
-            <Box ml='s'>
-              <Text color='alert'
-                variant='b3m'>
+      <Flex flexDirection='column'
+        height='100%'
+        p='s'>
+        <Box pt='s'>
+          <Box borderColor='gray.4'
+            borderRadius={3}
+            borderStyle='solid'
+            borderWidth={2}
+            p='s'>
+            <Flex>
+              <Icon Asset={SvgAlertCircle}
+                color='alert'
+                height={20}
+                width={20} />
+              <Box ml='s'>
+                <Text color='alert'
+                  variant='b3m'>
                 Attention
-              </Text>
-            </Box>
-          </Flex>
-          <Text color='gray.1'
-            variant='b2m'>
+                </Text>
+              </Box>
+            </Flex>
+            <Text color='gray.1'
+              variant='b2m'>
             You are about to remove this account. Once removed, this account will not be accessible via this extension unless you re-add it via JSON file or seed phrase.
-          </Text>
+            </Text>
+          </Box>
         </Box>
-      </Box>
-      <Flex flex={1}
-        flexDirection='column'
-        justifyContent='flex-end'
-        mb='s'
-        mx='xs'>
-        <Button busy={isBusy}
-          fluid
-          onClick={onExport}>
+        <Box mt='auto'
+          width='100%'>
+          <Button busy={isBusy}
+            fluid
+            onClick={onExport}>
           Forget account
-        </Button>
+          </Button>
+        </Box>
       </Flex>
     </>
   );

--- a/packages/ui/src/Popup/ForgetAccount/index.tsx
+++ b/packages/ui/src/Popup/ForgetAccount/index.tsx
@@ -35,29 +35,27 @@ export const ForgetAccount: FC = () => {
       <Flex flexDirection='column'
         height='100%'
         p='s'>
-        <Box pt='s'>
-          <Box borderColor='gray.4'
-            borderRadius={3}
-            borderStyle='solid'
-            borderWidth={2}
-            p='s'>
-            <Flex>
-              <Icon Asset={SvgAlertCircle}
-                color='alert'
-                height={20}
-                width={20} />
-              <Box ml='s'>
-                <Text color='alert'
-                  variant='b3m'>
+        <Box borderColor='gray.4'
+          borderRadius={3}
+          borderStyle='solid'
+          borderWidth={2}
+          p='s'>
+          <Flex>
+            <Icon Asset={SvgAlertCircle}
+              color='alert'
+              height={20}
+              width={20} />
+            <Box ml='s'>
+              <Text color='alert'
+                variant='b3m'>
                 Attention
-                </Text>
-              </Box>
-            </Flex>
-            <Text color='gray.1'
-              variant='b2m'>
+              </Text>
+            </Box>
+          </Flex>
+          <Text color='gray.1'
+            variant='b2m'>
             You are about to remove this account. Once removed, this account will not be accessible via this extension unless you re-add it via JSON file or seed phrase.
-            </Text>
-          </Box>
+          </Text>
         </Box>
         <Box mt='auto'
           width='100%'>

--- a/packages/ui/src/Popup/Signing/Request.tsx
+++ b/packages/ui/src/Popup/Signing/Request.tsx
@@ -227,7 +227,7 @@ export default function Request ({ account: { accountIndex, address, addressOffs
           </Warning>
         )}
         {warning && (
-          <Warning>
+          <Warning style={{ alignItems: 'center', alignSelf: 'flex-start', margin: '0 0 10px 0' }}>
             {warning}
           </Warning>
         )}

--- a/packages/ui/src/Popup/Signing/Request.tsx
+++ b/packages/ui/src/Popup/Signing/Request.tsx
@@ -231,7 +231,8 @@ export default function Request ({ account: { accountIndex, address, addressOffs
             {warning}
           </Warning>
         )}
-        <Flex flexDirection='row'
+        <Flex alignItems='stretch'
+          flexDirection='row'
           width='100%'>
           <Flex flex={1}>
             <Button
@@ -249,6 +250,7 @@ export default function Request ({ account: { accountIndex, address, addressOffs
                 disabled={ledgerStatus !== Status.Ok || hexBytes !== null}
                 fluid
                 onClick={_onSignLedger}
+                style={{ alignSelf: 'stretch' }}
                 type='submit'>
                 Sign on Ledger
               </Button>


### PR DESCRIPTION
- update style for warning message
<img width="320px" src="https://user-images.githubusercontent.com/7417976/111377479-15ce3d80-8677-11eb-97c6-0aa736c3c8e4.png" />

- give consistent padding to export account popup (WAL-128)
<img width="320px" src="https://user-images.githubusercontent.com/7417976/111377353-ea4b5300-8676-11eb-99c5-69db58fcff3f.png" />

- give consistent padding to forget account popup
<img width="320px" src="https://user-images.githubusercontent.com/7417976/111377669-4e6e1700-8677-11eb-8531-8fc3a79414cf.png" />

- keep request button heights same size during loading states
<img width="320px" src="https://user-images.githubusercontent.com/7417976/111376174-7fe5e300-8675-11eb-8d16-a4b7297fc6d7.png" />
