### PR TITLE
Ledger integration fixes

### DIFF
--- a/packages/ui/src/Popup/Accounts/AccountView.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountView.tsx
@@ -6,7 +6,7 @@ import React, { FC, useContext, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { AccountType, ActionContext, PolymeshContext } from '../../components';
+import { AccountContext, AccountType, ActionContext, PolymeshContext } from '../../components';
 import { editAccount, setPolySelectedAccount } from '../../messaging';
 import { Box, ButtonSmall, ContextMenuTrigger, Flex, Icon, LabelWithCopy, Menu, MenuItem, Text, TextInput, TextOverflowEllipsis } from '../../ui';
 import { formatters } from '../../util';
@@ -19,7 +19,10 @@ export interface Props {
 export const AccountView: FC<Props> = ({ account, isSelected }) => {
   const { address, balance, did, keyType, name } = account;
 
+  const { network } = useContext(PolymeshContext);
+  const { accounts } = useContext(AccountContext);
   const onAction = useContext(ActionContext);
+
   const history = useHistory();
 
   const [isEditing, setEditing] = useState(false);
@@ -27,16 +30,19 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
   const [hover, setHover] = useState(false);
   const [nameHover, setNameHover] = useState(false);
 
-  const { network } = useContext(PolymeshContext);
-
   const renderMenuItems = (address: string) => {
+    const account = accounts.find((_account) => _account.address === address);
+    const isLedgerAccount = account?.isHardware && account.hardwareType === 'ledger';
+
     return (
       <Menu id={`account_menu_${address}`}>
-        <MenuItem data={{ action: 'export', address }}
-          onClick={handleMenuClick}>
-          <Text color='gray.2'
-            variant='b1'>Export account</Text>
-        </MenuItem>
+        {!isLedgerAccount &&
+          <MenuItem data={{ action: 'export', address }}
+            onClick={handleMenuClick}>
+            <Text color='gray.2'
+              variant='b1'>Export account</Text>
+          </MenuItem>
+        }
         <MenuItem data={{ action: 'forget', address }}
           onClick={handleMenuClick}>
           <Text color='gray.2'

--- a/packages/ui/src/Popup/Accounts/index.tsx
+++ b/packages/ui/src/Popup/Accounts/index.tsx
@@ -20,7 +20,7 @@ const jsonPath = '/account/restore-json';
 const ledgerPath = '/account/import-ledger';
 
 export default function Accounts (): React.ReactElement {
-  const { hierarchy } = useContext(AccountContext);
+  const { accounts, hierarchy } = useContext(AccountContext);
   const { currentAccount, isDeveloper, network, polymeshAccounts, selectedAccount } = useContext(PolymeshContext);
   const history = useHistory();
   const { isLedgerCapable, isLedgerEnabled } = useLedger();
@@ -188,14 +188,18 @@ export default function Accounts (): React.ReactElement {
   };
 
   const renderTopMenu = () => {
+    const hasNonHardwareAccount = accounts.some((account) => !account.isHardware);
+
     return (
       <>
         <Menu id='top_menu'>
-          <MenuItem data={{ action: 'changePassword' }}
-            onClick={handleTopMenuSelection}>
-            <Text color='gray.2'
-              variant='b1'>Change password</Text>
-          </MenuItem>
+          {hasNonHardwareAccount &&
+            <MenuItem data={{ action: 'changePassword' }}
+              onClick={handleTopMenuSelection}>
+              <Text color='gray.2'
+                variant='b1'>Change password</Text>
+            </MenuItem>
+          }
           <MenuItem data={{ action: 'newWindow' }}
             onClick={handleTopMenuSelection}>
             <Text color='gray.2'
@@ -209,7 +213,6 @@ export default function Accounts (): React.ReactElement {
               onClick={(e) => e.preventDefault()}
               style={{ cursor: 'pointer' }}
             />
-
           </MenuItem>
         </Menu>
       </>

--- a/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
+++ b/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
@@ -76,8 +76,8 @@ function ImportLedger (): React.ReactElement {
       return indexOffsetMap;
     }, []);
 
-    for (let index = 0, shouldContinue = true; index < 20 && shouldContinue; index++) {
-      for (let offset = 0; offset < 20 && shouldContinue; offset++) {
+    for (let offset = 0, shouldContinue = true; offset < 20 && shouldContinue; offset++) {
+      for (let index = 0; index < 20 && shouldContinue; index++) {
         const isExistingIndexOffsetPair = existingIndexOffsetMap[index]?.includes(offset);
 
         if (!isExistingIndexOffsetPair) {

--- a/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
+++ b/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
@@ -197,7 +197,8 @@ function ImportLedger (): React.ReactElement {
                         <TextInput inputRef={register({ required: 'Account name is required' })}
                           name='accountName'
                           onChange={(e) => setName(e.target.value)}
-                          placeholder='Enter account name' />
+                          placeholder='Enter account name'
+                          value={name} />
                         <Box>
                           <Text color='alert'
                             variant='b3'>

--- a/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
+++ b/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
@@ -239,7 +239,7 @@ function ImportLedger (): React.ReactElement {
                   <Box mb='m'>
                     <Text color='gray.1'
                       variant='b2m' >
-                      Account index
+                      Account type
                     </Text>
                     <Dropdown
                       className='accountType'
@@ -252,7 +252,7 @@ function ImportLedger (): React.ReactElement {
                   <Box mb='m'>
                     <Text color='gray.1'
                       variant='b2m' >
-                      Address offset
+                      Address index
                     </Text>
                     <Dropdown
                       className='accountIndex'

--- a/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
+++ b/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
@@ -63,22 +63,24 @@ function ImportLedger (): React.ReactElement {
   // Set accountIndex and addressOffset to next available pair
   useEffect(() => {
     const ledgerAccounts = accounts.filter((account) => account.isHardware && account.hardwareType === 'ledger');
-    const existingPairsMap = ledgerAccounts.reduce((pairsMap: number[][], account) => {
+    const existingIndexOffsetMap = ledgerAccounts.reduce((indexOffsetMap: number[][], account) => {
       const index = account.accountIndex as number;
       const offset = account.addressOffset as number;
 
-      if (pairsMap[index]) {
-        pairsMap[index].push(offset);
+      if (indexOffsetMap[index]) {
+        indexOffsetMap[index].push(offset);
       } else {
-        pairsMap[index] = [offset];
+        indexOffsetMap[index] = [offset];
       }
 
-      return pairsMap;
+      return indexOffsetMap;
     }, []);
 
     for (let index = 0, shouldContinue = true; index < 20 && shouldContinue; index++) {
       for (let offset = 0; offset < 20 && shouldContinue; offset++) {
-        if (!existingPairsMap[index]?.includes(offset)) {
+        const isExistingIndexOffsetPair = existingIndexOffsetMap[index]?.includes(offset);
+
+        if (!isExistingIndexOffsetPair) {
           setAccountIndex(index);
           setAddressOffset(offset);
 


### PR DESCRIPTION
- Omits “export” option in account menu for Ledger accounts
- Omits “change password” option when the wallet does not have any non-hardware accounts
- Changed copy "Account type" to "Account index" and "Account index" to "Address offset", to match data
- Increments `accountIndex` and `addressOffset` values to next available pair by default.
Increments `addressOffset` value before incrementing `accountIndex`, i.e. finds pairs in this index/offset pattern: 0/0, 0/1, 0/2, ..., 19/18, 19/19

Known issues:

- changing `accountIndex` or `addressOffset` does not automatically change its counterpart value
For example: 
```
- the index/offset is set to 0/1
- user changes the index to 1
- the offset is still at 1 (should be 0, if 1/0 is free)
```