### PR TITLE
Increase wallet width

### DIFF
--- a/packages/core/src/background/handlers/State.ts
+++ b/packages/core/src/background/handlers/State.ts
@@ -33,7 +33,7 @@ const WINDOW_OPTS = {
   top: 150,
   type: 'popup',
   url: chrome.extension.getURL('index.html'),
-  width: 328
+  width: 400
 };
 
 function getId (): string {

--- a/packages/extension/public/index.html
+++ b/packages/extension/public/index.html
@@ -19,10 +19,10 @@
         margin: 0 auto;
         padding: 0;
         text-align: left;
-        width: 328px;
+        width: 400px;
         height: calc(100% - 2px);
         max-width: 100%;
-        min-width: 328px;
+        min-width: 400px;
       "
     ></div>
     <script src="./extension.js"></script>

--- a/packages/extension/public/notification.html
+++ b/packages/extension/public/notification.html
@@ -19,10 +19,10 @@
         margin: 0 auto;
         padding: 0;
         text-align: left;
-        width: 328px;
+        width: 400px;
         height: calc(100% - 2px);
         max-width: 100%;
-        min-width: 328px;
+        min-width: 400px;
       "
     ></div>
     <script src="./extension.js"></script>

--- a/packages/ui/src/Popup/Accounts/AccountView.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountView.tsx
@@ -364,7 +364,7 @@ const AccountViewGrid = styled.div`
   display: grid;
   grid-template-areas: 'avatar account-details options';
   gap: 10px;
-  grid-template-columns: 35px 200px 35px;
+  grid-template-columns: 35px auto 35px;
 `;
 
 const AccountDetailsGrid = styled.div`

--- a/packages/ui/src/createView.tsx
+++ b/packages/ui/src/createView.tsx
@@ -10,7 +10,7 @@ export default function createView (Entry: React.ComponentType, rootId = 'root')
   // First thing, we set window size because the default window size is too wide.
   // There's hardly any clean way to accomplish this, since window size is set initially
   // via chrome.windows.create, which is invoked by Polkadot's singing request handling.
-  window.resizeTo(328, 621);
+  window.resizeTo(400, 621);
 
   const rootElement = document.getElementById(rootId);
 

--- a/packages/ui/src/hooks/useIsPopup.ts
+++ b/packages/ui/src/hooks/useIsPopup.ts
@@ -3,6 +3,6 @@ import { useMemo } from 'react';
 export default function useIsPopup (): boolean {
   return useMemo(() => {
     // @TODO adjust this whenever we readjust width.
-    return window.innerWidth <= 328;
+    return window.innerWidth <= 400;
   }, []);
 }


### PR DESCRIPTION
- Increased the width of the wallet popup to 400px as per design suggestions
- Adjusted displaying account info to take up more space

Screenshots:
<img width="400" alt="Screen Shot 2021-03-19 at 11 07 21" src="https://user-images.githubusercontent.com/7417976/111802155-0f70d900-88a4-11eb-82cb-7653c1bebc26.png">

<img width="512" alt="Screen Shot 2021-03-19 at 11 06 48" src="https://user-images.githubusercontent.com/7417976/111802218-20214f00-88a4-11eb-9a3f-58f8331e4cb7.png">
