### PR TITLE
Issue #6: error handling for extrinsicSign

### DIFF
--- a/packages/ui/src/Popup/Signing/Request.tsx
+++ b/packages/ui/src/Popup/Signing/Request.tsx
@@ -71,12 +71,16 @@ export default function Request ({ account: { accountIndex, address, addressOffs
         payload: null
       });
     } else {
-      registry.setSignedExtensions(payload.signedExtensions);
+      try {
+        registry.setSignedExtensions(payload.signedExtensions);
 
-      setData({
-        hexBytes: null,
-        payload: registry.createType('ExtrinsicPayload', payload, { version: payload.version })
-      });
+        setData({
+          hexBytes: null,
+          payload: registry.createType('ExtrinsicPayload', payload, { version: payload.version })
+        });
+      } catch (error) {
+        setError(error.toString());
+      }
     }
   }, [request]);
 
@@ -218,17 +222,6 @@ export default function Request ({ account: { accountIndex, address, addressOffs
     : (
       <Flex flexDirection='column'
         p='s'>
-        {error && (
-          <Warning isDanger
-            style={{ alignItems: 'center', alignSelf: 'flex-start', marginBottom: '10px' }}>
-            {error}
-          </Warning>
-        )}
-        {warning && (
-          <Warning style={{ alignItems: 'center', alignSelf: 'flex-start', margin: '0 0 10px 0' }}>
-            {warning}
-          </Warning>
-        )}
         <Flex alignItems='stretch'
           flexDirection='row'
           width='100%'>
@@ -254,6 +247,7 @@ export default function Request ({ account: { accountIndex, address, addressOffs
               </Button>
               : <Button
                 busy={isBusy}
+                disabled={!!error}
                 fluid
                 onClick={_onSignQuick}
                 type='submit'>
@@ -292,7 +286,17 @@ export default function Request ({ account: { accountIndex, address, addressOffs
         </Box>
         {content()}
       </RequestContent>
-
+      {error && (
+        <Warning isDanger
+          style={{ alignItems: 'center', alignSelf: 'flex-start', marginBottom: '10px' }}>
+          {error}
+        </Warning>
+      )}
+      {warning && (
+        <Warning style={{ alignItems: 'center', alignSelf: 'flex-start', margin: '0 0 10px 0' }}>
+          {warning}
+        </Warning>
+      )}
       {signArea}
     </>
   );

--- a/packages/ui/src/Popup/Signing/Unlock.tsx
+++ b/packages/ui/src/Popup/Signing/Unlock.tsx
@@ -100,6 +100,7 @@ function Unlock ({ error, isFirst, isLocked, onCancel, onSavePassChange, onSign,
         {isFirst && <Flex flex={1}
           ml='xs'>
           <Button busy={isBusy}
+            disabled={!!error}
             fluid
             form='passwordForm'
             type='submit'>


### PR DESCRIPTION
An authorized app may cause a temporary denial of service by sending a malformed extrinsic.sign request, and make the victim to restart his/her browser to able to use the wallet again.

To reproduce, you can send this message to the extension from your browser's console. Make sure you're browsing an app that has been authorised previously (eg token studio or polkadot apps).

```
var msg = {"id":"0.1","message":"","origin":"page","request":{"address":"5GpHvX9RRr8ZcJHcGcWQrR56wtNLcwi3CF1sDqVKvu395XRA","blockHash":"0x95a1a4fe9b4e4543e76e2108d6242ca881a5ad5be6cb06eea1aee24b218277d8","blockNumber":"0x003039e6","era”:”'”,”genesisHash":"0x12fddc9e2128b3fe571e4e5427addcb87fcaf08493867a68dd6ae44b406b39c7","method":"0x0400ff5a2657cbdd86be4ceb4d34eda4ec80668d58c96825a8bba657ddd0e1f785581c02093d00","nonce":"0x00000006'","signedExtensions":["CheckSpecVersion","CheckTxVersion","CheckGenesis","CheckMortality","CheckNonce","CheckWeight","ChargeTransactionPayment","StoreCallMetadata"],"specVersion":"0x000007df","tip":"0x00000000000000000000000000000000","transactionVersion":"0x00000006","version":4}};
msg.message = "pub(extrinsic.sign)";
window.postMessage(msg, "*");
```

Before fix:

<img width="402" alt="Screen Shot 2021-03-30 at 1 23 51 PM" src="https://user-images.githubusercontent.com/1994818/113052920-905d8980-915c-11eb-8b30-ad75d8edd2fc.png">

After fix:

<img width="402" alt="Screen Shot 2021-03-30 at 1 21 51 PM" src="https://user-images.githubusercontent.com/1994818/113052933-97849780-915c-11eb-8c4e-02027bc14f8f.png">
