### PR TITLE
[WAL-142][SEV1] authorize user before deleting an account

### DIFF
--- a/packages/ui/src/Popup/ForgetAccount/index.tsx
+++ b/packages/ui/src/Popup/ForgetAccount/index.tsx
@@ -6,7 +6,7 @@ import { useForm } from 'react-hook-form';
 import { useParams } from 'react-router';
 
 import { ActionContext, ActivityContext } from '../../components';
-import { forgetAccount } from '../../messaging';
+import { forgetAccount, validatePassword } from '../../messaging';
 
 interface ParamTypes {
   address: string
@@ -22,13 +22,19 @@ export const ForgetAccount: FC = () => {
   const isBusy = useContext(ActivityContext);
   const handleError = useErrorHandler();
 
-  const { errors, handleSubmit, register } = useForm<PasswordForm>();
+  const { errors, handleSubmit, register, setError } = useForm<PasswordForm>();
 
   const onSubmit = async ({ currentPassword }: PasswordForm) => {
     try {
-      await forgetAccount(address, currentPassword);
+      const isValidPassword = await validatePassword(currentPassword);
 
-      onAction('/');
+      if (isValidPassword) {
+        await forgetAccount(address);
+
+        onAction('/');
+      } else {
+        setError('currentPassword', { type: 'WrongPassword' });
+      }
     } catch (e) {
       handleError(e);
     }
@@ -72,7 +78,7 @@ export const ForgetAccount: FC = () => {
             <Box>
               <Text color='gray.1'
                 variant='b2m'>
-              Wallet password
+                Wallet password
               </Text>
             </Box>
             <Box>

--- a/packages/ui/src/Popup/ForgetAccount/index.tsx
+++ b/packages/ui/src/Popup/ForgetAccount/index.tsx
@@ -1,7 +1,8 @@
 import { SvgAlertCircle, SvgFileLockOutline } from '@polymathnetwork/extension-ui/assets/images/icons';
-import { Box, Button, Flex, Header, Icon, Text } from '@polymathnetwork/extension-ui/ui';
+import { Box, Button, Flex, Header, Icon, Text, TextInput } from '@polymathnetwork/extension-ui/ui';
 import React, { FC, useContext } from 'react';
 import { useErrorHandler } from 'react-error-boundary';
+import { useForm } from 'react-hook-form';
 import { useParams } from 'react-router';
 
 import { ActionContext, ActivityContext } from '../../components';
@@ -11,15 +12,21 @@ interface ParamTypes {
   address: string
 }
 
+type PasswordForm = {
+  currentPassword: string;
+}
+
 export const ForgetAccount: FC = () => {
   const onAction = useContext(ActionContext);
   const { address } = useParams<ParamTypes>();
   const isBusy = useContext(ActivityContext);
   const handleError = useErrorHandler();
 
-  const onExport = async () => {
+  const { errors, handleSubmit, register } = useForm<PasswordForm>();
+
+  const onSubmit = async ({ currentPassword }: PasswordForm) => {
     try {
-      await forgetAccount(address);
+      await forgetAccount(address, currentPassword);
 
       onAction('/');
     } catch (e) {
@@ -58,10 +65,40 @@ export const ForgetAccount: FC = () => {
             You are about to remove this account. Once removed, this account will not be accessible via this extension unless you re-add it via JSON file or seed phrase.
           </Text>
         </Box>
+
+        <form id='passwordForm'
+          onSubmit={handleSubmit(onSubmit)}>
+          <Box mt='m'>
+            <Box>
+              <Text color='gray.1'
+                variant='b2m'>
+              Wallet password
+              </Text>
+            </Box>
+            <Box>
+              <TextInput inputRef={register({ required: true, minLength: 8 })}
+                name='currentPassword'
+                placeholder='Enter your wallet password'
+                type='password' />
+              {errors.currentPassword &&
+              <Box>
+                <Text color='alert'
+                  variant='b3'>
+                  {(errors.currentPassword).type === 'required' && 'Required field'}
+                  {(errors.currentPassword).type === 'minLength' && 'Password too short'}
+                  {(errors.currentPassword).type === 'WrongPassword' && 'Invalid password'}
+                </Text>
+              </Box>
+              }
+            </Box>
+          </Box>
+        </form>
+
         <Box mt='auto'>
           <Button busy={isBusy}
             fluid
-            onClick={onExport}>
+            form='passwordForm'
+            type='submit'>
             Forget account
           </Button>
         </Box>

--- a/packages/ui/src/messaging.ts
+++ b/packages/ui/src/messaging.ts
@@ -182,8 +182,8 @@ export async function validateAccount (address: string, password: string): Promi
   return sendMessage('pri(accounts.validate)', { address, password });
 }
 
-export async function forgetAccount (address: string, password: string): Promise<boolean> {
-  return sendMessage('pri(accounts.forget)', { address, password });
+export async function forgetAccount (address: string): Promise<boolean> {
+  return sendMessage('pri(accounts.forget)', { address });
 }
 
 export async function approveAuthRequest (id: string): Promise<boolean> {

--- a/packages/ui/src/messaging.ts
+++ b/packages/ui/src/messaging.ts
@@ -182,8 +182,8 @@ export async function validateAccount (address: string, password: string): Promi
   return sendMessage('pri(accounts.validate)', { address, password });
 }
 
-export async function forgetAccount (address: string): Promise<boolean> {
-  return sendMessage('pri(accounts.forget)', { address });
+export async function forgetAccount (address: string, password: string): Promise<boolean> {
+  return sendMessage('pri(accounts.forget)', { address, password });
 }
 
 export async function approveAuthRequest (id: string): Promise<boolean> {


### PR DESCRIPTION
Require password input and validating password before forgetting an account, unless it's a Ledger account, in which case no password validation is required.

Screenshot:
<img width="400" src="https://user-images.githubusercontent.com/7417976/113062384-a5004880-9181-11eb-9bff-cd1adfd7a1cf.png" />
