### PR TITLE
[WAL-127] improve account selection

### DIFF
--- a/packages/ui/src/Popup/Accounts/AccountView.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountView.tsx
@@ -118,7 +118,7 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
   };
 
   const selectAccount = async () => {
-    if (address) {
+    if (address && !isEditing) {
       await setPolySelectedAccount(address);
       onAction();
     }

--- a/packages/ui/src/Popup/Accounts/AccountView.tsx
+++ b/packages/ui/src/Popup/Accounts/AccountView.tsx
@@ -316,31 +316,30 @@ export const AccountView: FC<Props> = ({ account, isSelected }) => {
       <Box
         bg={hover ? 'gray.5' : 'gray.0'}
         mt='s'
+        onClick={selectAccount}
         onMouseEnter={mouseEnter}
         onMouseLeave={mouseLeave}
         px='s'
+        style={{ cursor: 'pointer' }}
       >
         <AccountViewGrid>
-          <Box onClick={selectAccount}
-            style={{ cursor: 'pointer' }}>
-            <Flex height='100%'>
-              <Box
-                backgroundColor='brandLightest'
-                borderRadius='50%'
-                height={32}
-                px='2'
-                width={32}
-              >
-                <Flex justifyContent='center'
-                  pt='xxs'>
-                  <Text color='brandMain'
-                    variant='b2m'>
-                    {name?.substr(0, 1)}
-                  </Text>
-                </Flex>
-              </Box>
-            </Flex>
-          </Box>
+          <Flex height='100%'>
+            <Box
+              backgroundColor='brandLightest'
+              borderRadius='50%'
+              height={32}
+              px='2'
+              width={32}
+            >
+              <Flex justifyContent='center'
+                pt='xxs'>
+                <Text color='brandMain'
+                  variant='b2m'>
+                  {name?.substr(0, 1)}
+                </Text>
+              </Flex>
+            </Box>
+          </Flex>
           <Box>
             {(!hover || did) && renderAccountInfo()}
             {hover && !did && renderHoverAccountInfo()}


### PR DESCRIPTION
Previously account selections were made by clicking the initial-avatar circle, which was a bit unintuitive.

This PR allows selecting an account by clicking any part of the account card — that does not already have a clickable action, i.e. copy and edit.

This makes account selection easier and feels more natural. Please try it out!