### PR TITLE
Validate uid provision network

### DIFF
--- a/packages/core/src/background/handlers/Tabs.ts
+++ b/packages/core/src/background/handlers/Tabs.ts
@@ -9,7 +9,7 @@ import polyNetworkSubscribe from '@polymathnetwork/extension-core/external/polyN
 import { getSelectedAccount, getSelectedIdentifiedAccount } from '@polymathnetwork/extension-core/store/getters';
 import { subscribeSelectedAccount } from '@polymathnetwork/extension-core/store/subscribers';
 import { NetworkMeta, ProofRequestPayload, RequestPolyProvideUid } from '@polymathnetwork/extension-core/types';
-import { allowedUidProvider, prioritize, recodeAddress, validateDid, validateNetwork, validateTicker, validateUid } from '@polymathnetwork/extension-core/utils';
+import { allowedUidProvider, prioritize, recodeAddress, validateDid, validateNetwork, validateSelectedNetwork, validateTicker, validateUid } from '@polymathnetwork/extension-core/utils';
 
 import { Errors, PolyMessageTypes, PolyRequestTypes, PolyResponseTypes, ProofingResponse } from '../types';
 import State from './State';
@@ -122,6 +122,8 @@ export default class Tabs extends DotTabs {
     const { did, network, uid } = request;
 
     assert(validateNetwork(network), `Invalid network ${JSON.stringify(network)}`);
+
+    assert(validateSelectedNetwork(network), `Network ${JSON.stringify(network)} doesn't match the selected network in Polymesh Wallet`);
 
     assert(validateDid(did), Errors.DID_NOT_MATCH);
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -4,7 +4,7 @@ import { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
 import { validate as uuidValidate, version as uuidVersion } from 'uuid';
 
-import { getDids } from './store/getters';
+import { getDids, getNetwork } from './store/getters';
 import { apiError, setError } from './store/setters';
 import { defaultSs58Format, uidProvidersWhitelist } from './constants';
 import { AccountBalances, ErrorCodes, KeyringAccountData, NetworkName } from './types';
@@ -73,6 +73,12 @@ export const validateTicker = (ticker: string): boolean => {
 
 export const validateNetwork = (network: string): boolean => {
   return !!network && Object.keys(NetworkName).indexOf(network) > -1;
+};
+
+export const validateSelectedNetwork = (network: NetworkName): boolean => {
+  const selectedNetwork = getNetwork();
+
+  return network === selectedNetwork;
 };
 
 export const validateDid = (did: string): boolean => {


### PR DESCRIPTION
It can be really confusing when user imports an ITN-specific uid, while Alcyone is the active network in their wallet. After this PR, uid provision request handler well validate the provided network against the selected one, then throw an error if they mismatch.
