### PR TITLE
Misc fixes + 0.5.4

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.5.3"
+  "version": "0.5.4"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymesh-wallet",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A Wallet extension for Polymesh blockchain",
   "private": true,
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymathnetwork/extension-core",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/core/src/background/handlers/Tabs.ts
+++ b/packages/core/src/background/handlers/Tabs.ts
@@ -119,7 +119,7 @@ export default class Tabs extends DotTabs {
   private provideUid (url: string, request: RequestPolyProvideUid): Promise<boolean> {
     assert(allowedUidProvider(url), `App ${url} is not allowed to provide uid`);
 
-    const { did, network, uid } = request;
+    const { network, uid } = request;
 
     assert(validateNetwork(network), `Invalid network ${JSON.stringify(network)}`);
 

--- a/packages/core/src/background/handlers/Tabs.ts
+++ b/packages/core/src/background/handlers/Tabs.ts
@@ -9,7 +9,7 @@ import polyNetworkSubscribe from '@polymathnetwork/extension-core/external/polyN
 import { getSelectedAccount, getSelectedIdentifiedAccount } from '@polymathnetwork/extension-core/store/getters';
 import { subscribeSelectedAccount } from '@polymathnetwork/extension-core/store/subscribers';
 import { NetworkMeta, ProofRequestPayload, RequestPolyProvideUid } from '@polymathnetwork/extension-core/types';
-import { allowedUidProvider, prioritize, recodeAddress, validateDid, validateNetwork, validateSelectedNetwork, validateTicker, validateUid } from '@polymathnetwork/extension-core/utils';
+import { allowedUidProvider, prioritize, recodeAddress, validateNetwork, validateSelectedNetwork, validateTicker, validateUid } from '@polymathnetwork/extension-core/utils';
 
 import { Errors, PolyMessageTypes, PolyRequestTypes, PolyResponseTypes, ProofingResponse } from '../types';
 import State from './State';
@@ -143,6 +143,8 @@ export default class Tabs extends DotTabs {
     const account = getSelectedIdentifiedAccount();
 
     assert(account, 'No account is present or no account selected');
+
+    if (!account.did) { return false; }
 
     return uidRecords.some(({ did }) => did === account.did);
   }

--- a/packages/core/src/background/handlers/Tabs.ts
+++ b/packages/core/src/background/handlers/Tabs.ts
@@ -125,7 +125,12 @@ export default class Tabs extends DotTabs {
 
     assert(validateSelectedNetwork(network), `Network ${JSON.stringify(network)} doesn't match the selected network in Polymesh Wallet`);
 
-    assert(validateDid(did), Errors.DID_NOT_MATCH);
+    // FIXME we're disabling this check temporarily.
+    // The problem is, CDD providers will create DID and attempt to push uid in on go.
+    // Until user opens wallet popup, it would have no awareness of the newly created DID,
+    // and will ultimately reject the uid provision request.
+
+    // assert(validateDid(did), Errors.DID_NOT_MATCH);
 
     assert(validateUid(uid), Errors.INVALID_UID);
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polymathnetwork/extension",
   "description": "A Wallet extension for Polymesh blockchain",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "dependencies": {
     "@babel/runtime": "^7.12.13",
@@ -14,8 +14,8 @@
     "@polkadot/phishing": "^0.6.1",
     "@polkadot/ui-keyring": "^0.70.1",
     "@polkadot/ui-settings": "^0.70.1",
-    "@polymathnetwork/extension-core": "0.5.3",
-    "@polymathnetwork/extension-ui": "0.5.3"
+    "@polymathnetwork/extension-core": "0.5.4",
+    "@polymathnetwork/extension-ui": "0.5.4"
   },
   "devDependencies": {
     "@polkadot/dev": "^0.61.30",

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -33,10 +33,9 @@ chrome.runtime.onConnect.addListener((port): void => {
     `Unknown connection from ${port.name}`
   );
   let polyUnsub: () => Promise<void>;
-  let accountsUnsub: VoidCallback;
+  const accountsUnsub = accountsSynchronizer();
 
   if (port.name === PORTS.EXTENSION) {
-    accountsUnsub = accountsSynchronizer();
     polyUnsub = subscribePolymesh();
     loadSchema();
 
@@ -47,10 +46,12 @@ chrome.runtime.onConnect.addListener((port): void => {
         polyUnsub()
           .then(() => console.log('ApiPromise: disconnected')).catch(console.error);
       }
-
-      if (accountsUnsub) accountsUnsub();
     });
   }
+
+  port.onDisconnect.addListener((): void => {
+    if (accountsUnsub) accountsUnsub();
+  });
 
   // message handlers
   port.onMessage.addListener((data): void => {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polymathnetwork/extension-ui",
   "description": "A sample signer extension for the @polkadot/api",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "license": "Apache-2",
   "type": "module",
   "dependencies": {

--- a/packages/ui/src/Popup/Accounts/AddAccount.tsx
+++ b/packages/ui/src/Popup/Accounts/AddAccount.tsx
@@ -1,7 +1,7 @@
-import { SvgLedger, SvgPolyNew } from '@polymathnetwork/extension-ui/assets/images/icons';
-import useIsPopup from '@polymathnetwork/extension-ui/hooks/useIsPopup';
-import { useLedger } from '@polymathnetwork/extension-ui/hooks/useLedger';
-import { windowOpen } from '@polymathnetwork/extension-ui/messaging';
+import { SvgPolyNew } from '@polymathnetwork/extension-ui/assets/images/icons';
+// import useIsPopup from '@polymathnetwork/extension-ui/hooks/useIsPopup';
+// import { useLedger } from '@polymathnetwork/extension-ui/hooks/useLedger';
+// import { windowOpen } from '@polymathnetwork/extension-ui/messaging';
 import React, { useCallback, useContext, useState } from 'react';
 
 import { ActionContext } from '../../components';
@@ -11,24 +11,24 @@ function AddAccount (): React.ReactElement {
   const onAction = useContext(ActionContext);
   const [policyAccepted, setPolicyAccepted] = useState(false);
   const [termsAccepted, setTermsAccepted] = useState(false);
-  const isPopup = useIsPopup();
-  const { isLedgerEnabled } = useLedger();
+  // const isPopup = useIsPopup();
+  // const { isLedgerEnabled } = useLedger();
 
-  const _onOpenLedgerConnect = useCallback(
-    () => windowOpen('/account/import-ledger'),
-    []
-  );
+  // const _onOpenLedgerConnect = useCallback(
+  //   () => windowOpen('/account/import-ledger'),
+  //   []
+  // );
   const onCreateAccount = useCallback((): void => onAction('/account/create'), [onAction]);
 
   const onImportAccount = useCallback((): void => onAction('/account/restore'), [onAction]);
 
-  const onConnectLedger = useCallback((): void => {
-    if (!isLedgerEnabled && isPopup) {
-      _onOpenLedgerConnect().then(console.log).catch(console.error);
-    } else {
-      onAction('/account/import-ledger');
-    }
-  }, [_onOpenLedgerConnect, isLedgerEnabled, isPopup, onAction]);
+  // const onConnectLedger = useCallback((): void => {
+  //   if (!isLedgerEnabled && isPopup) {
+  //     _onOpenLedgerConnect().then(console.log).catch(console.error);
+  //   } else {
+  //     onAction('/account/import-ledger');
+  //   }
+  // }, [_onOpenLedgerConnect, isLedgerEnabled, isPopup, onAction]);
 
   return (
     <>
@@ -125,7 +125,7 @@ function AddAccount (): React.ReactElement {
               Restore account
             </Button>
           </Box>
-          <Box mt='s'
+          {/* <Box mt='s'
             mx='xs'>
             <Button disabled={!(policyAccepted && termsAccepted)}
               fluid
@@ -138,7 +138,7 @@ function AddAccount (): React.ReactElement {
               </Box>
               Connect your Ledger
             </Button>
-          </Box>
+          </Box> */}
         </Box>
       </Flex>
     </>


### PR DESCRIPTION
- Remove "Connect Ledger" option from wallet's onboarding screen.
- Fix an issue that is manifested as shown in the steps below. The problem was that we didn't hydrate the Redux store (which includes the selected account, amongst other data), until user open wallet popup. If they don't, we don't hydrate Redux store, and hence, no account appears as selected. The solution was to hydrate Redux store as soon as an App or the wallet Popup connect to wallet.
    - Wallet gets updated from chrome store OR user reloads the extension deliberately from extensions page.
    - User visits Fractal.
    - When the app queries the selected user, the wallet returns with an error that `No account is present or no account selected`.
- Another issue of similar nature occurs when Fractal creates DID and uID in one go, and attempts to push the latter to the wallet. The wallet would have no awareness of the newly created DID yet, and will prevent the uid provision. That validation has been removed for now.