### PR TITLE
WAL-161: do not reset persisted state

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,7 +12,7 @@ import { actions as identityActions } from './store/features/identities';
 import { actions as networkActions } from './store/features/network';
 import { actions as statusActions } from './store/features/status';
 import { getAccountsList, getNetwork } from './store/getters';
-import { subscribeDidsList, subscribeIsHydratedAndNetwork } from './store/subscribers';
+import { subscribeDidsList, subscribeSelectedNetwork } from './store/subscribers';
 import { populatedDelay } from './constants';
 import store from './store';
 import { AccountData, KeyringAccountData, UnsubCallback } from './types';
@@ -116,7 +116,7 @@ function subscribePolymesh (): () => Promise<void> {
   console.log('Poly: fetching data from chain');
 
   !!unsubCallbacks.network && unsubCallbacks.network();
-  unsubCallbacks.network = subscribeIsHydratedAndNetwork((network) => {
+  unsubCallbacks.network = subscribeSelectedNetwork((network) => {
     if (network) {
       console.log('Poly: Selected network', network);
       store.dispatch(statusActions.init());

--- a/packages/core/src/store/features/status.ts
+++ b/packages/core/src/store/features/status.ts
@@ -1,7 +1,7 @@
 import { Error, NetworkName, StoreStatus } from '@polymathnetwork/extension-core/types';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-const initialState: StoreStatus = { rehydrated: false, error: null, apiStatus: 'connecting', populated: {} };
+const initialState: StoreStatus = { error: null, apiStatus: 'connecting', populated: {} };
 
 const statusSlice = createSlice({
   name: 'status',
@@ -17,9 +17,6 @@ const statusSlice = createSlice({
     },
     apiError (state) {
       state.apiStatus = 'error';
-    },
-    setRehydrated (state) {
-      state.rehydrated = true;
     },
     populated (state, action: PayloadAction<NetworkName>) {
       state.populated[action.payload] = true;

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -4,13 +4,12 @@ import { FLUSH,
   PAUSE,
   PERSIST,
   persistReducer,
-  persistStore,
-  PURGE,
+  persistStore, PURGE,
   REGISTER, REHYDRATE } from 'redux-persist';
+import hardSet from 'redux-persist/lib/stateReconciler/hardSet';
 import { localStorage } from 'redux-persist-webextension-storage';
 
-import rootReducer from './rootReducer';
-import { setIsRehydrated } from './setters';
+import rootReducer, { AppReducer, RootState } from './rootReducer';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -18,10 +17,11 @@ const persistConfig = {
   key: 'root',
   storage: localStorage,
   version: 1,
-  blacklist: ['status']
+  blacklist: ['status'],
+  stateReconciler: hardSet
 };
 
-const persistedReducer = persistReducer(persistConfig, rootReducer);
+const persistedReducer = persistReducer<RootState>(persistConfig, rootReducer);
 
 const middleware = [...getDefaultMiddleware({ serializableCheck: {
   ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER]
@@ -31,9 +31,9 @@ if (isDev) {
   middleware.push(logger);
 }
 
-const store: any = configureStore({
+const store = configureStore({
   middleware,
-  reducer: persistedReducer,
+  reducer: persistedReducer as unknown as AppReducer,
   devTools: isDev
 });
 
@@ -48,8 +48,6 @@ if (isDev && (module as any).hot) {
 
 export type Dispatch = typeof store.dispatch
 
-export const persister = persistStore(store, null, () => {
-  setIsRehydrated();
-});
+export const persister = persistStore(store);
 
 export default store;

--- a/packages/core/src/store/rootReducer.ts
+++ b/packages/core/src/store/rootReducer.ts
@@ -1,4 +1,4 @@
-import { AnyAction, combineReducers } from '@reduxjs/toolkit';
+import { combineReducers } from '@reduxjs/toolkit';
 
 import accounts from './features/accounts';
 import identities from './features/identities';
@@ -12,14 +12,6 @@ const appReducer = combineReducers({
   status
 });
 
-const rootReducer = (state: RootState, action: AnyAction): typeof appReducer => {
-  if (action.type === 'RESET') {
-    // @ts-ignore
-    state = undefined;
-  }
-
-  return appReducer(state, action) as unknown as typeof appReducer;
-};
-
 export type RootState = ReturnType<typeof appReducer>;
-export default rootReducer as unknown as typeof appReducer;
+export type AppReducer = typeof appReducer;
+export default appReducer;

--- a/packages/core/src/store/selectors.ts
+++ b/packages/core/src/store/selectors.ts
@@ -94,16 +94,16 @@ export const selectedAccountIdentified = createSelector(
   }
 );
 
-export const selectIsRehydrated = createSelector(
-  (state: RootState) => state.status,
-  ({ rehydrated }) => rehydrated
-);
+// export const selectIsRehydrated = createSelector(
+//   (state: RootState) => state.status,
+//   ({ rehydrated }) => rehydrated
+// );
 
-export const selectIsHydratedAndNetwork = createSelector(
-  selectIsRehydrated,
-  selectedNetwork,
-  (isHydrated, network) => { return isHydrated ? network : undefined; }
-);
+// export const selectIsHydratedAndNetwork = createSelector(
+//   selectIsRehydrated,
+//   selectedNetwork,
+//   (isHydrated, network) => { return isHydrated ? network : undefined; }
+// );
 
 export const selectStatus = createSelector(
   (state: RootState) => state.status,

--- a/packages/core/src/store/subscribers.ts
+++ b/packages/core/src/store/subscribers.ts
@@ -2,7 +2,7 @@ import { Unsubscribe } from '@reduxjs/toolkit';
 
 import { IdentifiedAccount, NetworkName, NetworkState, StoreStatus } from '../types';
 import reduxSubscribe from './reduxSubscribe';
-import { accountsCount, didsList, identifiedAccounts, network, selectedAccount, selectedNetwork, selectIsHydratedAndNetwork, selectIsRehydrated, selectStatus } from './selectors';
+import { accountsCount, didsList, identifiedAccounts, network, selectedAccount, selectedNetwork, selectStatus } from './selectors';
 
 export function subscribeDidsList (cb: (dids: string[]) => void): Unsubscribe {
   return reduxSubscribe(didsList, cb);
@@ -30,12 +30,4 @@ export function subscribeAccountsCount (cb: (count: number) => void): Unsubscrib
 
 export function subscribeStatus (cb: (status: StoreStatus) => void): Unsubscribe {
   return reduxSubscribe(selectStatus, cb);
-}
-
-export function subscribeIsRehydrated (cb: (isRehydrated: boolean) => void): Unsubscribe {
-  return reduxSubscribe(selectIsRehydrated, cb);
-}
-
-export function subscribeIsHydratedAndNetwork (cb: (network: NetworkName | undefined) => void): Unsubscribe {
-  return reduxSubscribe(selectIsHydratedAndNetwork, cb);
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -138,7 +138,6 @@ export type Error = {
 }
 
 export type StoreStatus = {
-  rehydrated: boolean,
   error: Error | null,
   apiStatus: 'ready' | 'connecting' | 'error',
   populated: Record<string, boolean>,

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -8,7 +8,6 @@ import subscribePolymesh, { accountsSynchronizer } from '@polymathnetwork/extens
 import handlers from '@polymathnetwork/extension-core/background/handlers';
 import { PORTS } from '@polymathnetwork/extension-core/constants';
 import SchemaService from '@polymathnetwork/extension-core/external/schema';
-import { resetState, setIsRehydrated } from '@polymathnetwork/extension-core/store/setters';
 import { fatalErrorHandler } from '@polymathnetwork/extension-core/utils';
 
 const loadSchema = () => {
@@ -20,9 +19,6 @@ chrome.browserAction.setBadgeBackgroundColor({ color: '#d90000' });
 
 // This listener is invoked every time the extension is installed, updated, or reloaded.
 chrome.runtime.onInstalled.addListener(() => {
-  // Reset stored state to avoid integrity issues. Store will be repopulated next time the wallet is opened.
-  resetState();
-  setIsRehydrated();
   loadSchema();
 });
 


### PR DESCRIPTION
Also
- Remove `state.status.hydrated` since it was useless.
- Specify redux-persist's reconciliation to `hardSet`, which means that incoming state from Redux always overrides what's in localstorage.
- Cleaned up store typing.