### PR TITLE
[WAL-125][WAL-166] Option selector component

### DIFF
--- a/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
+++ b/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
@@ -1,7 +1,8 @@
 import { networkIsDev, networkLabels } from '@polymathnetwork/extension-core/constants';
 import { NetworkName } from '@polymathnetwork/extension-core/types';
 import { SvgCheck, SvgChevron } from '@polymathnetwork/extension-ui/assets/images/icons';
-import { Option, OptionSelector, PolymeshContext } from '@polymathnetwork/extension-ui/components';
+import { OptionSelector, PolymeshContext } from '@polymathnetwork/extension-ui/components';
+import { CategoryOptions, Option } from '@polymathnetwork/extension-ui/components/OptionSelector';
 import { styled } from '@polymathnetwork/extension-ui/styles';
 import { Box, Flex, Icon, Text } from '@polymathnetwork/extension-ui/ui';
 import React, { useContext, useEffect, useRef, useState } from 'react';
@@ -63,7 +64,49 @@ export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorPr
     };
   }, [isDropdownShowing]);
 
-  const networkOptions: Option[] = Object.entries(networkLabels)
+  const networkOptions: CategoryOptions[] = [
+    {
+      category: 'Networks',
+      options: Object.entries(networkLabels)
+        .filter(([_network]) => isDeveloper || (!isDeveloper && !networkIsDev[_network as NetworkName]))
+        .map(([_network, networkLabel]) => {
+          return {
+            label: (
+              <Flex
+                className='network-item'
+                key={_network}
+                // onClick={() => onSelect(_network as NetworkName)}
+                px='16px'
+                py='8px'
+              >
+                <NetworkCircle
+                  background={NETWORK_COLORS[_network as NetworkName].backgrounds[0]}
+                  color={NETWORK_COLORS[_network as NetworkName].foreground}
+                  size='24px'
+                  thickness='4px'
+                />
+                <Box ml='8px'
+                  mr='auto'>
+                  <Text variant='b2m'>{networkLabel}</Text>
+                </Box>
+
+                {selected === _network && (
+                  <Box ml='auto'>
+                    <Icon Asset={SvgCheck}
+                      color='brandMain'
+                      height={24}
+                      width={24} />
+                  </Box>
+                )}
+              </Flex>
+            ),
+            value: _network
+          };
+        })
+    }
+  ];
+
+  const networkOptionsB: Option[] = Object.entries(networkLabels)
     .filter(([_network]) => isDeveloper || (!isDeveloper && !networkIsDev[_network as NetworkName]))
     .map(([_network, networkLabel]) => {
       return {

--- a/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
+++ b/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
@@ -2,7 +2,7 @@ import { networkIsDev, networkLabels } from '@polymathnetwork/extension-core/con
 import { NetworkName } from '@polymathnetwork/extension-core/types';
 import { SvgCheck, SvgChevron } from '@polymathnetwork/extension-ui/assets/images/icons';
 import { OptionSelector, PolymeshContext } from '@polymathnetwork/extension-ui/components';
-import { CategoryOptions, Option } from '@polymathnetwork/extension-ui/components/OptionSelector';
+import { Option } from '@polymathnetwork/extension-ui/components/OptionSelector';
 import { styled } from '@polymathnetwork/extension-ui/styles';
 import { Box, Flex, Icon, Text } from '@polymathnetwork/extension-ui/ui';
 import React, { useContext, useEffect, useRef, useState } from 'react';
@@ -111,27 +111,30 @@ export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorPr
   };
 
   return (
-    <OptionSelector minWidth='296px'
+    <OptionSelector
+      minWidth='296px'
       onSelect={changeNetwork}
-      options={networkOptions}>
-      <NetworkSelect background={background}
-        onClick={showDropdown}>
-        <NetworkCircle background={background}
-          color={foreground} />
-        <Box ml='4px'
-          mr='7px'>
-          <Text color={foreground}
-            variant='b3m'>
-            {networkLabels[currentNetwork]}
-          </Text>
-        </Box>
-        <DropdownIcon background={backgroundLight}>
-          <Icon Asset={SvgChevron}
-            color={foreground}
-            rotate='180deg' />
-        </DropdownIcon>
-      </NetworkSelect>
-    </OptionSelector>
+      options={networkOptions}
+      selector={
+        <NetworkSelect background={background}
+          onClick={showDropdown}>
+          <NetworkCircle background={background}
+            color={foreground} />
+          <Box ml='4px'
+            mr='7px'>
+            <Text color={foreground}
+              variant='b3m'>
+              {networkLabels[currentNetwork]}
+            </Text>
+          </Box>
+          <DropdownIcon background={backgroundLight}>
+            <Icon Asset={SvgChevron}
+              color={foreground}
+              rotate='180deg' />
+          </DropdownIcon>
+        </NetworkSelect>
+      }
+    ></OptionSelector>
   );
 
   // return (

--- a/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
+++ b/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
@@ -1,7 +1,7 @@
 import { networkIsDev, networkLabels } from '@polymathnetwork/extension-core/constants';
 import { NetworkName } from '@polymathnetwork/extension-core/types';
 import { SvgCheck, SvgChevron } from '@polymathnetwork/extension-ui/assets/images/icons';
-import { PolymeshContext } from '@polymathnetwork/extension-ui/components';
+import { Option, OptionSelector, PolymeshContext } from '@polymathnetwork/extension-ui/components';
 import { styled } from '@polymathnetwork/extension-ui/styles';
 import { Box, Flex, Icon, Text } from '@polymathnetwork/extension-ui/ui';
 import React, { useContext, useEffect, useRef, useState } from 'react';
@@ -11,7 +11,7 @@ const DEV_NETWORK_COLORS = {
   foreground: '#1348E4'
 };
 
-const NETWORK_COLORS: Record<NetworkName, { backgrounds: string[], foreground: string }> = {
+const NETWORK_COLORS: Record<NetworkName, { backgrounds: string[]; foreground: string }> = {
   itn: {
     backgrounds: ['#F2E6FF', '#4D019840'],
     foreground: '#4D0198'
@@ -28,7 +28,7 @@ const NETWORK_COLORS: Record<NetworkName, { backgrounds: string[], foreground: s
 type NetworkSelectorProps = {
   currentNetwork: NetworkName;
   onSelect: (network: NetworkName) => void;
-}
+};
 
 export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorProps): React.ReactElement {
   const { networkState: { isDeveloper, selected } } = useContext(PolymeshContext);
@@ -63,8 +63,46 @@ export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorPr
     };
   }, [isDropdownShowing]);
 
+  const networkOptions: Option[] = Object.entries(networkLabels)
+    .filter(([_network]) => isDeveloper || (!isDeveloper && !networkIsDev[_network as NetworkName]))
+    .map(([_network, networkLabel]) => {
+      return {
+        label: (
+          <Flex
+            className='network-item'
+            key={_network}
+            onClick={() => onSelect(_network as NetworkName)}
+            px='16px'
+            py='8px'
+          >
+            <NetworkCircle
+              background={NETWORK_COLORS[_network as NetworkName].backgrounds[0]}
+              color={NETWORK_COLORS[_network as NetworkName].foreground}
+              size='24px'
+              thickness='4px'
+            />
+            <Box ml='8px'
+              mr='auto'>
+              <Text variant='b2m'>{networkLabel}</Text>
+            </Box>
+
+            {selected === _network && (
+              <Box ml='auto'>
+                <Icon Asset={SvgCheck}
+                  color='brandMain'
+                  height={24}
+                  width={24} />
+              </Box>
+            )}
+          </Flex>
+        ),
+        value: _network
+      };
+    });
+
   return (
-    <Wrapper>
+    <OptionSelector minWidth='296px'
+      options={networkOptions}>
       <NetworkSelect background={background}
         onClick={showDropdown}>
         <NetworkCircle background={background}
@@ -82,59 +120,80 @@ export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorPr
             rotate='180deg' />
         </DropdownIcon>
       </NetworkSelect>
-
-      {isDropdownShowing &&
-        <NetworkDropdown borderRadius='8px'
-          py='8px'
-          ref={dropdownRef}
-          width='296px'>
-          <Box mx='16px'>
-            <Text color='gray.2'
-              variant='b2m'>
-                Networks
-            </Text>
-          </Box>
-          {Object.entries(networkLabels)
-            .filter(([_network]) => isDeveloper || (!isDeveloper && !networkIsDev[_network as NetworkName]))
-            .map(([_network, networkLabel]) => {
-              return (
-                <Flex className='network-item'
-                  key={_network}
-                  onClick={() => onSelect(_network as NetworkName)}
-                  px='16px'
-                  py='8px'>
-                  <NetworkCircle background={NETWORK_COLORS[_network as NetworkName].backgrounds[0]}
-                    color={NETWORK_COLORS[_network as NetworkName].foreground}
-                    size='24px'
-                    thickness='4px'/>
-                  <Box ml='8px'
-                    mr='auto'>
-                    <Text variant='b2m'>
-                      {networkLabel}
-                    </Text>
-                  </Box>
-                  {selected === _network &&
-                    <Icon
-                      Asset={SvgCheck}
-                      color='brandMain'
-                      height={24}
-                      width={24}
-                    />
-                  }
-                </Flex>
-              );
-            })}
-        </NetworkDropdown>
-      }
-    </Wrapper>
+    </OptionSelector>
   );
+
+  // return (
+  // <Wrapper>
+  // <NetworkSelect background={background}
+  //   onClick={showDropdown}>
+  //   <NetworkCircle background={background}
+  //     color={foreground} />
+  //   <Box ml='4px'
+  //     mr='7px'>
+  //     <Text color={foreground}
+  //       variant='b3m'>
+  //       {networkLabels[currentNetwork]}
+  //     </Text>
+  //   </Box>
+  //   <DropdownIcon background={backgroundLight}>
+  //     <Icon Asset={SvgChevron}
+  //       color={foreground}
+  //       rotate='180deg' />
+  //   </DropdownIcon>
+  // </NetworkSelect>
+  //   {isDropdownShowing &&
+  //     <NetworkDropdown borderRadius='8px'
+  //       py='8px'
+  //       ref={dropdownRef}
+  //       width='296px'>
+  //       <Box mx='16px'>
+  //         <Text color='gray.2'
+  //           variant='b2m'>
+  //             Networks
+  //         </Text>
+  //       </Box>
+  //       {Object.entries(networkLabels)
+  //         .filter(([_network]) => isDeveloper || (!isDeveloper && !networkIsDev[_network as NetworkName]))
+  //         .map(([_network, networkLabel]) => {
+  //           return (
+  //             <Flex className='network-item'
+  //               key={_network}
+  //               onClick={() => onSelect(_network as NetworkName)}
+  //               px='16px'
+  //               py='8px'>
+  //               <NetworkCircle background={NETWORK_COLORS[_network as NetworkName].backgrounds[0]}
+  //                 color={NETWORK_COLORS[_network as NetworkName].foreground}
+  //                 size='24px'
+  //                 thickness='4px'/>
+  //               <Box ml='8px'
+  //                 mr='auto'>
+  //                 <Text variant='b2m'>
+  //                   {networkLabel}
+  //                 </Text>
+  //               </Box>
+  //               {selected === _network &&
+  //                 <Icon
+  //                   Asset={SvgCheck}
+  //                   color='brandMain'
+  //                   height={24}
+  //                   width={24}
+  //                 />
+  //               }
+  //             </Flex>
+  //           );
+  //         })}
+  //     </NetworkDropdown>
+  //   }
+  // </Wrapper>
+  // );
 }
 
 const Wrapper = styled.div`
   position: relative;
 `;
 
-const NetworkSelect = styled.div<{ background: string; }>`
+const NetworkSelect = styled.div<{ background: string }>`
   display: flex;
   align-items: center;
   height: 24px;
@@ -144,7 +203,7 @@ const NetworkSelect = styled.div<{ background: string; }>`
   cursor: pointer;
 `;
 
-const DropdownIcon = styled.div<{ background: string; }>`
+const DropdownIcon = styled.div<{ background: string }>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -154,7 +213,7 @@ const DropdownIcon = styled.div<{ background: string; }>`
   background-color: ${(props) => props.background};
 `;
 
-const NetworkCircle = styled.span<{ background: string; color: string; size?: string; thickness?: string; }>`
+const NetworkCircle = styled.span<{ background: string; color: string; size?: string; thickness?: string }>`
   display: inline-box;
   width: ${(props) => props.size || '12px'};
   height: ${(props) => props.size || '12px'};
@@ -162,6 +221,7 @@ const NetworkCircle = styled.span<{ background: string; color: string; size?: st
   box-sizing: border-box;
   border: ${(props) => props.thickness || '2px'} solid ${(props) => props.color};
   border-radius: 50%;
+  flex-shrink: 0;
 `;
 
 const NetworkDropdown = styled(Box)`

--- a/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
+++ b/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
@@ -27,12 +27,11 @@ const NETWORK_COLORS: Record<NetworkName, { backgrounds: string[]; foreground: s
 };
 
 type NetworkSelectorProps = {
-  currentNetwork: NetworkName;
   onSelect: (network: NetworkName) => void;
 };
 
-export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorProps): React.ReactElement {
-  const { networkState: { isDeveloper, selected } } = useContext(PolymeshContext);
+export function NetworkSelector ({ onSelect }: NetworkSelectorProps): React.ReactElement {
+  const { networkState: { isDeveloper, selected: currentNetwork } } = useContext(PolymeshContext);
 
   const [background, backgroundLight] = NETWORK_COLORS[currentNetwork].backgrounds;
   const foreground = NETWORK_COLORS[currentNetwork].foreground;
@@ -62,7 +61,7 @@ export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorPr
                   <Text variant='b2m'>{networkLabel}</Text>
                 </Box>
 
-                {selected === _network && (
+                {currentNetwork === _network && (
                   <Box ml='auto'>
                     <Icon Asset={SvgCheck}
                       color='brandMain'

--- a/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
+++ b/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
@@ -71,7 +71,7 @@ export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorPr
           <Flex
             className='network-item'
             key={_network}
-            onClick={() => onSelect(_network as NetworkName)}
+            // onClick={() => onSelect(_network as NetworkName)}
             px='16px'
             py='8px'
           >
@@ -100,8 +100,13 @@ export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorPr
       };
     });
 
+  const changeNetwork = (network: NetworkName) => {
+    console.log({ network });
+  };
+
   return (
     <OptionSelector minWidth='296px'
+      onSelect={changeNetwork}
       options={networkOptions}>
       <NetworkSelect background={background}
         onClick={showDropdown}>

--- a/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
+++ b/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
@@ -64,7 +64,7 @@ export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorPr
     };
   }, [isDropdownShowing]);
 
-  const networkOptions: CategoryOptions[] = [
+  const networkOptions: Option[] = [
     {
       category: 'Networks',
       options: Object.entries(networkLabels)
@@ -105,43 +105,6 @@ export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorPr
         })
     }
   ];
-
-  const networkOptionsB: Option[] = Object.entries(networkLabels)
-    .filter(([_network]) => isDeveloper || (!isDeveloper && !networkIsDev[_network as NetworkName]))
-    .map(([_network, networkLabel]) => {
-      return {
-        label: (
-          <Flex
-            className='network-item'
-            key={_network}
-            // onClick={() => onSelect(_network as NetworkName)}
-            px='16px'
-            py='8px'
-          >
-            <NetworkCircle
-              background={NETWORK_COLORS[_network as NetworkName].backgrounds[0]}
-              color={NETWORK_COLORS[_network as NetworkName].foreground}
-              size='24px'
-              thickness='4px'
-            />
-            <Box ml='8px'
-              mr='auto'>
-              <Text variant='b2m'>{networkLabel}</Text>
-            </Box>
-
-            {selected === _network && (
-              <Box ml='auto'>
-                <Icon Asset={SvgCheck}
-                  color='brandMain'
-                  height={24}
-                  width={24} />
-              </Box>
-            )}
-          </Flex>
-        ),
-        value: _network
-      };
-    });
 
   const changeNetwork = (network: NetworkName) => {
     console.log({ network });

--- a/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
+++ b/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
@@ -5,7 +5,7 @@ import { OptionSelector, PolymeshContext } from '@polymathnetwork/extension-ui/c
 import { Option } from '@polymathnetwork/extension-ui/components/OptionSelector';
 import { styled } from '@polymathnetwork/extension-ui/styles';
 import { Box, Flex, Icon, Text } from '@polymathnetwork/extension-ui/ui';
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext } from 'react';
 
 const DEV_NETWORK_COLORS = {
   backgrounds: ['#DCEFFE', '#1348E440'],
@@ -34,35 +34,8 @@ type NetworkSelectorProps = {
 export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorProps): React.ReactElement {
   const { networkState: { isDeveloper, selected } } = useContext(PolymeshContext);
 
-  const [isDropdownShowing, setIsDropdownShowing] = useState(false);
-
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
   const [background, backgroundLight] = NETWORK_COLORS[currentNetwork].backgrounds;
   const foreground = NETWORK_COLORS[currentNetwork].foreground;
-
-  const showDropdown = () => {
-    setIsDropdownShowing(true);
-  };
-
-  const handleClick = (event: MouseEvent) => {
-    const hasClickedOutside = !dropdownRef.current?.contains(event.target as Node);
-
-    if (hasClickedOutside) {
-      setIsDropdownShowing(false);
-    }
-  };
-
-  // Toggle click listener to hide dropdown, when clicked outside of dropdown
-  useEffect(() => {
-    if (isDropdownShowing) {
-      document.addEventListener('mousedown', handleClick);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClick);
-    };
-  }, [isDropdownShowing]);
 
   const networkOptions: Option[] = [
     {
@@ -75,7 +48,6 @@ export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorPr
               <Flex
                 className='network-item'
                 key={_network}
-                // onClick={() => onSelect(_network as NetworkName)}
                 px='16px'
                 py='8px'
               >
@@ -106,18 +78,13 @@ export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorPr
     }
   ];
 
-  const changeNetwork = (network: NetworkName) => {
-    console.log({ network });
-  };
-
   return (
     <OptionSelector
       minWidth='296px'
-      onSelect={changeNetwork}
+      onSelect={onSelect}
       options={networkOptions}
       selector={
-        <NetworkSelect background={background}
-          onClick={showDropdown}>
+        <NetworkSelect background={background}>
           <NetworkCircle background={background}
             color={foreground} />
           <Box ml='4px'
@@ -134,78 +101,9 @@ export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorPr
           </DropdownIcon>
         </NetworkSelect>
       }
-    ></OptionSelector>
+    />
   );
-
-  // return (
-  // <Wrapper>
-  // <NetworkSelect background={background}
-  //   onClick={showDropdown}>
-  //   <NetworkCircle background={background}
-  //     color={foreground} />
-  //   <Box ml='4px'
-  //     mr='7px'>
-  //     <Text color={foreground}
-  //       variant='b3m'>
-  //       {networkLabels[currentNetwork]}
-  //     </Text>
-  //   </Box>
-  //   <DropdownIcon background={backgroundLight}>
-  //     <Icon Asset={SvgChevron}
-  //       color={foreground}
-  //       rotate='180deg' />
-  //   </DropdownIcon>
-  // </NetworkSelect>
-  //   {isDropdownShowing &&
-  //     <NetworkDropdown borderRadius='8px'
-  //       py='8px'
-  //       ref={dropdownRef}
-  //       width='296px'>
-  //       <Box mx='16px'>
-  //         <Text color='gray.2'
-  //           variant='b2m'>
-  //             Networks
-  //         </Text>
-  //       </Box>
-  //       {Object.entries(networkLabels)
-  //         .filter(([_network]) => isDeveloper || (!isDeveloper && !networkIsDev[_network as NetworkName]))
-  //         .map(([_network, networkLabel]) => {
-  //           return (
-  //             <Flex className='network-item'
-  //               key={_network}
-  //               onClick={() => onSelect(_network as NetworkName)}
-  //               px='16px'
-  //               py='8px'>
-  //               <NetworkCircle background={NETWORK_COLORS[_network as NetworkName].backgrounds[0]}
-  //                 color={NETWORK_COLORS[_network as NetworkName].foreground}
-  //                 size='24px'
-  //                 thickness='4px'/>
-  //               <Box ml='8px'
-  //                 mr='auto'>
-  //                 <Text variant='b2m'>
-  //                   {networkLabel}
-  //                 </Text>
-  //               </Box>
-  //               {selected === _network &&
-  //                 <Icon
-  //                   Asset={SvgCheck}
-  //                   color='brandMain'
-  //                   height={24}
-  //                   width={24}
-  //                 />
-  //               }
-  //             </Flex>
-  //           );
-  //         })}
-  //     </NetworkDropdown>
-  //   }
-  // </Wrapper>
-  // );
 }
-
-const Wrapper = styled.div`
-  position: relative;
-`;
 
 const NetworkSelect = styled.div<{ background: string }>`
   display: flex;
@@ -236,21 +134,4 @@ const NetworkCircle = styled.span<{ background: string; color: string; size?: st
   border: ${(props) => props.thickness || '2px'} solid ${(props) => props.color};
   border-radius: 50%;
   flex-shrink: 0;
-`;
-
-const NetworkDropdown = styled(Box)`
-  position: absolute;
-  background: white;
-  box-shadow: ${(props) => props.theme.shadows[3]};
-  top: calc(100% + 4px);
-  left: 0;
-  z-index: 1;
-
-  .network-item {
-    cursor: pointer;
-
-    &:hover {
-      background: ${(props) => props.theme.colors.gray[5]};
-    }
-  }
 `;

--- a/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
+++ b/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
@@ -40,7 +40,7 @@ export function NetworkSelector ({ currentNetwork, onSelect }: NetworkSelectorPr
   const networkOptions: Option[] = [
     {
       category: 'Networks',
-      options: Object.entries(networkLabels)
+      menu: Object.entries(networkLabels)
         .filter(([_network]) => isDeveloper || (!isDeveloper && !networkIsDev[_network as NetworkName]))
         .map(([_network, networkLabel]) => {
           return {

--- a/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
+++ b/packages/ui/src/Popup/Accounts/NetworkSelector.tsx
@@ -3,6 +3,7 @@ import { NetworkName } from '@polymathnetwork/extension-core/types';
 import { SvgCheck, SvgChevron } from '@polymathnetwork/extension-ui/assets/images/icons';
 import { OptionSelector, PolymeshContext } from '@polymathnetwork/extension-ui/components';
 import { Option } from '@polymathnetwork/extension-ui/components/OptionSelector';
+import { colors } from '@polymathnetwork/extension-ui/components/themeDefinitions';
 import { styled } from '@polymathnetwork/extension-ui/styles';
 import { Box, Flex, Icon, Text } from '@polymathnetwork/extension-ui/ui';
 import React, { useContext } from 'react';
@@ -40,19 +41,22 @@ export function NetworkSelector ({ onSelect }: NetworkSelectorProps): React.Reac
     {
       category: 'Networks',
       menu: Object.entries(networkLabels)
-        .filter(([_network]) => isDeveloper || (!isDeveloper && !networkIsDev[_network as NetworkName]))
-        .map(([_network, networkLabel]) => {
+        .filter(([network]) => isDeveloper || (!isDeveloper && !networkIsDev[network as NetworkName]))
+        .map(([network, networkLabel]) => {
+          const isCurrentNetwork = currentNetwork === network;
+
           return {
             label: (
               <Flex
                 className='network-item'
-                key={_network}
+                key={network}
                 px='16px'
                 py='8px'
+                {...(isCurrentNetwork && { style: { background: colors.gray[5] } })}
               >
                 <NetworkCircle
-                  background={NETWORK_COLORS[_network as NetworkName].backgrounds[0]}
-                  color={NETWORK_COLORS[_network as NetworkName].foreground}
+                  background={NETWORK_COLORS[network as NetworkName].backgrounds[0]}
+                  color={NETWORK_COLORS[network as NetworkName].foreground}
                   size='24px'
                   thickness='4px'
                 />
@@ -61,7 +65,7 @@ export function NetworkSelector ({ onSelect }: NetworkSelectorProps): React.Reac
                   <Text variant='b2m'>{networkLabel}</Text>
                 </Box>
 
-                {currentNetwork === _network && (
+                {isCurrentNetwork && (
                   <Box ml='auto'>
                     <Icon Asset={SvgCheck}
                       color='brandMain'
@@ -71,7 +75,7 @@ export function NetworkSelector ({ onSelect }: NetworkSelectorProps): React.Reac
                 )}
               </Flex>
             ),
-            value: _network
+            value: network
           };
         })
     }

--- a/packages/ui/src/Popup/Accounts/index.tsx
+++ b/packages/ui/src/Popup/Accounts/index.tsx
@@ -21,7 +21,7 @@ const jsonPath = '/account/restore-json';
 const ledgerPath = '/account/import-ledger';
 
 export default function Accounts (): React.ReactElement {
-  const { hierarchy } = useContext(AccountContext);
+  const { accounts, hierarchy } = useContext(AccountContext);
   const { currentAccount,
     networkState: { isDeveloper, selected: network },
     polymeshAccounts,
@@ -128,10 +128,12 @@ export default function Accounts (): React.ReactElement {
     }
   };
 
+  const hasNonHardwareAccount = accounts.some((account) => !account.isHardware);
+
   const topMenuOptions: Option[] = [
     {
       menu: [
-        { label: 'Change password', value: 'changePassword' },
+        ...(hasNonHardwareAccount ? [{ label: 'Change password', value: 'changePassword' }] : []),
         { label: 'Open extension in a new tab', value: 'newWindow' },
         {
           label: (

--- a/packages/ui/src/Popup/Accounts/index.tsx
+++ b/packages/ui/src/Popup/Accounts/index.tsx
@@ -128,6 +128,28 @@ export default function Accounts (): React.ReactElement {
     }
   };
 
+  const topMenuOptions: Option[] = [
+    {
+      options: [
+        { label: 'Change password', value: 'changePassword' },
+        { label: 'Open extension in a new tab', value: 'newWindow' },
+        {
+          label: (
+            <Flex px='16px'
+              py='8px'>
+              <Checkbox checked={isDeveloper}
+                disabled />
+              <Box ml='s'>
+                <Text variant='b2m'>Display development networks</Text>
+              </Box>
+            </Flex>
+          ),
+          value: 'toggleIsDev'
+        }
+      ]
+    }
+  ];
+
   const handleTopMenuSelection = (value: string) => {
     switch (value) {
       case 'changePassword':
@@ -139,92 +161,15 @@ export default function Accounts (): React.ReactElement {
     }
   };
 
-  const renderTopMenuButton = () => {
-    const options = [
-      {
-        options: [
-          { label: 'Change password', value: 'changePassword' },
-          { label: 'Open extension in a new tab', value: 'newWindow' },
-          {
-            label: (
-              <Flex px='16px'
-                py='8px'>
-                <Checkbox checked={isDeveloper}
-                  disabled />
-                <Box ml='s'>
-                  <Text variant='b2m'>Display development networks</Text>
-                </Box>
-              </Flex>
-            ),
-            value: 'toggleIsDev'
-          }
-        ]
-      }
-    ];
-
-    return (
-      <OptionSelector
-        onSelect={handleTopMenuSelection}
-        options={options}
-        position='bottom-right'
-        selector={<Icon Asset={SvgDotsVertical}
-          color='gray.0'
-          height={24}
-          style={{ cursor: 'pointer' }}
-          width={24} />}
-      />
-    );
-  };
-
   const openDashboard = () => {
     chrome.tabs.create({ url: getNetworkDashboardLink() });
   };
 
-  const renderTopMenu = () => {
-    const hasNonHardwareAccount = accounts.some((account) => !account.isHardware);
-
-    return (
-      <>
-        <Menu id='top_menu'>
-          {hasNonHardwareAccount && (
-            <MenuItem data={{ action: 'changePassword' }}
-              onClick={handleTopMenuSelection}>
-              <Text color='gray.2'
-                variant='b1'>
-                Change password
-              </Text>
-            </MenuItem>
-          )}
-          <MenuItem data={{ action: 'newWindow' }}
-            onClick={handleTopMenuSelection}>
-            <Text color='gray.2'
-              variant='b1'>
-              Open extension in a new tab
-            </Text>
-          </MenuItem>
-          <MenuItem data={{ action: 'toggleIsDev' }}
-            onClick={handleTopMenuSelection}>
-            <Checkbox
-              checked={isDeveloper}
-              disabled
-              label={<Text color='gray.2'>Display development networks</Text>}
-              onClick={(e) => e.preventDefault()}
-              style={{ cursor: 'pointer' }}
-            />
-          </MenuItem>
-        </Menu>
-      </>
-    );
-  };
-
   return (
     <>
-      {/* {renderTopMenu()} */}
       {renderAccountMenuItems()}
       {hierarchy.length === 0
-        ? (
-          <AddAccount />
-        )
+        ? <AddAccount />
         : (
           <>
             <Header>
@@ -238,7 +183,18 @@ export default function Accounts (): React.ReactElement {
                   justifyContent='center'>
                   <GrowingButton icon={SvgViewDashboard}
                     onClick={openDashboard} />
-                  {renderTopMenuButton()}
+                  <OptionSelector
+                    onSelect={handleTopMenuSelection}
+                    options={topMenuOptions}
+                    position='bottom-right'
+                    selector={
+                      <Icon Asset={SvgDotsVertical}
+                        color='gray.0'
+                        height={24}
+                        style={{ cursor: 'pointer' }}
+                        width={24} />
+                    }
+                  />
                 </Flex>
               </Flex>
               {currentAccount && <AccountsHeader account={currentAccount}

--- a/packages/ui/src/Popup/Accounts/index.tsx
+++ b/packages/ui/src/Popup/Accounts/index.tsx
@@ -21,7 +21,7 @@ const jsonPath = '/account/restore-json';
 const ledgerPath = '/account/import-ledger';
 
 export default function Accounts (): React.ReactElement {
-  const { accounts, hierarchy } = useContext(AccountContext);
+  const { hierarchy } = useContext(AccountContext);
   const { currentAccount,
     networkState: { isDeveloper, selected: network },
     polymeshAccounts,
@@ -177,8 +177,7 @@ export default function Accounts (): React.ReactElement {
                 flexDirection='row'
                 justifyContent='space-between'
                 mb='m'>
-                <NetworkSelector currentNetwork={network}
-                  onSelect={setNetwork} />
+                <NetworkSelector onSelect={setNetwork} />
                 <Flex flexDirection='row'
                   justifyContent='center'>
                   <GrowingButton icon={SvgViewDashboard}

--- a/packages/ui/src/Popup/Accounts/index.tsx
+++ b/packages/ui/src/Popup/Accounts/index.tsx
@@ -1,7 +1,7 @@
 import { networkLinks } from '@polymathnetwork/extension-core/constants';
 import { IdentifiedAccount, NetworkName } from '@polymathnetwork/extension-core/types';
-import { SvgDotsVertical,
-  SvgPlus, SvgViewDashboard } from '@polymathnetwork/extension-ui/assets/images/icons';
+import { SvgDotsVertical, SvgPlus, SvgViewDashboard } from '@polymathnetwork/extension-ui/assets/images/icons';
+import { Option } from '@polymathnetwork/extension-ui/components/OptionSelector';
 import useIsPopup from '@polymathnetwork/extension-ui/hooks/useIsPopup';
 import { useLedger } from '@polymathnetwork/extension-ui/hooks/useLedger';
 import { setPolyNetwork, togglePolyIsDev, windowOpen } from '@polymathnetwork/extension-ui/messaging';
@@ -10,8 +10,8 @@ import React, { useCallback, useContext } from 'react';
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
 
-import { AccountContext, PolymeshContext } from '../../components';
-import { Checkbox, ContextMenuTrigger, Flex, GrowingButton, Header, Icon, Menu, MenuItem, Text } from '../../ui';
+import { AccountContext, OptionSelector, PolymeshContext } from '../../components';
+import { Box, Checkbox, ContextMenuTrigger, Flex, GrowingButton, Header, Icon, Menu, MenuItem, Text } from '../../ui';
 import { AccountsContainer } from './AccountsContainer';
 import { AccountsHeader } from './AccountsHeader';
 import AddAccount from './AddAccount';
@@ -22,26 +22,24 @@ const ledgerPath = '/account/import-ledger';
 
 export default function Accounts (): React.ReactElement {
   const { accounts, hierarchy } = useContext(AccountContext);
-  const { currentAccount, networkState: { isDeveloper, selected: network }, polymeshAccounts, selectedAccount } = useContext(PolymeshContext);
+  const { currentAccount,
+    networkState: { isDeveloper, selected: network },
+    polymeshAccounts,
+    selectedAccount } = useContext(PolymeshContext);
   const history = useHistory();
   const { isLedgerCapable, isLedgerEnabled } = useLedger();
 
   const isPopup = useIsPopup();
 
-  const _openJson = useCallback(
-    () => windowOpen(jsonPath)
-    , []);
+  const _openJson = useCallback(() => windowOpen(jsonPath), []);
 
-  const _onOpenLedgerConnect = useCallback(
-    () => windowOpen(ledgerPath),
-    []
-  );
+  const _onOpenLedgerConnect = useCallback(() => windowOpen(ledgerPath), []);
 
   const getNetworkDashboardLink = () => {
     return networkLinks[network].dashboard;
   };
 
-  const groupAccounts = () => (array:IdentifiedAccount[]) =>
+  const groupAccounts = () => (array: IdentifiedAccount[]) =>
     array.reduce((groupedAccounts: Record<string, IdentifiedAccount[]>, account: IdentifiedAccount) => {
       const value = account.did ? account.did : 'unassigned';
 
@@ -71,49 +69,55 @@ export default function Accounts (): React.ReactElement {
           <MenuItem data={{ action: 'new' }}
             onClick={handleAccountMenuClick}>
             <Text color='gray.2'
-              variant='b1'>Create new account</Text>
+              variant='b1'>
+              Create new account
+            </Text>
           </MenuItem>
           <MenuItem data={{ action: 'fromSeed' }}
             onClick={handleAccountMenuClick}>
             <Text color='gray.2'
-              variant='b1'>Restore with recovery phrase</Text>
+              variant='b1'>
+              Restore with recovery phrase
+            </Text>
           </MenuItem>
           <MenuItem data={{ action: 'fromJson' }}
             onClick={handleAccountMenuClick}>
             <Text color='gray.2'
-              variant='b1'>Import account with JSON file</Text>
+              variant='b1'>
+              Import account with JSON file
+            </Text>
           </MenuItem>
 
           {
             // @TODO to be re-enabled once Polymesh Ledger app is released.
-            false && (
-              isLedgerEnabled
-                ? <MenuItem
-                  disabled={!isLedgerCapable}
-                  onClick={
-                    () => history.push('/account/import-ledger')
-                  }>
-                  <Text color='gray.2'
-                    variant='b1'>{
-                      !isLedgerCapable ? 'Ledger devices can only be connected with Chrome browser' : 'Attach ledger account'
-                    }</Text>
-                </MenuItem>
-
-                : <MenuItem
-                  onClick={_onOpenLedgerConnect}>
-                  <Text color='gray.2'
-                    variant='b1'>{'Connect Ledger device'}</Text>
-                </MenuItem>
-
-            )
+            false &&
+              (isLedgerEnabled
+                ? (
+                  <MenuItem disabled={!isLedgerCapable}
+                    onClick={() => history.push('/account/import-ledger')}>
+                    <Text color='gray.2'
+                      variant='b1'>
+                      {!isLedgerCapable
+                        ? 'Ledger devices can only be connected with Chrome browser'
+                        : 'Attach ledger account'}
+                    </Text>
+                  </MenuItem>
+                )
+                : (
+                  <MenuItem onClick={_onOpenLedgerConnect}>
+                    <Text color='gray.2'
+                      variant='b1'>
+                      {'Connect Ledger device'}
+                    </Text>
+                  </MenuItem>
+                ))
           }
-
         </Menu>
       </>
     );
   };
 
-  const handleAccountMenuClick = (event: string, data: {action: string}) => {
+  const handleAccountMenuClick = (event: string, data: { action: string }) => {
     switch (data.action) {
       case 'new':
         return history.push('/account/create');
@@ -124,8 +128,8 @@ export default function Accounts (): React.ReactElement {
     }
   };
 
-  const handleTopMenuSelection = (event: string, data: {action: string}) => {
-    switch (data.action) {
+  const handleTopMenuSelection = (value: string) => {
+    switch (value) {
       case 'changePassword':
         return history.push('/account/change-password');
       case 'newWindow':
@@ -136,18 +140,39 @@ export default function Accounts (): React.ReactElement {
   };
 
   const renderTopMenuButton = () => {
-    return (
-      <>
-        <ContextMenuTrigger id='top_menu'
-          mouseButton={0}>
-          <Icon Asset={SvgDotsVertical}
-            color='gray.0'
-            height={24}
-            style={{ cursor: 'pointer' }}
-            width={24} />
-        </ContextMenuTrigger>
-      </>
+    const options = [
+      {
+        options: [
+          { label: 'Change password', value: 'changePassword' },
+          { label: 'Open extension in a new tab', value: 'newWindow' },
+          {
+            label: (
+              <Flex px='16px'
+                py='8px'>
+                <Checkbox checked={isDeveloper}
+                  disabled />
+                <Box ml='s'>
+                  <Text variant='b2m'>Display development networks</Text>
+                </Box>
+              </Flex>
+            ),
+            value: 'toggleIsDev'
+          }
+        ]
+      }
+    ];
 
+    return (
+      <OptionSelector
+        onSelect={handleTopMenuSelection}
+        options={options}
+        position='bottom-right'
+        selector={<Icon Asset={SvgDotsVertical}
+          color='gray.0'
+          height={24}
+          style={{ cursor: 'pointer' }}
+          width={24} />}
+      />
     );
   };
 
@@ -161,21 +186,26 @@ export default function Accounts (): React.ReactElement {
     return (
       <>
         <Menu id='top_menu'>
-          {hasNonHardwareAccount &&
+          {hasNonHardwareAccount && (
             <MenuItem data={{ action: 'changePassword' }}
               onClick={handleTopMenuSelection}>
               <Text color='gray.2'
-                variant='b1'>Change password</Text>
+                variant='b1'>
+                Change password
+              </Text>
             </MenuItem>
-          }
+          )}
           <MenuItem data={{ action: 'newWindow' }}
             onClick={handleTopMenuSelection}>
             <Text color='gray.2'
-              variant='b1'>Open extension in a new tab</Text>
+              variant='b1'>
+              Open extension in a new tab
+            </Text>
           </MenuItem>
           <MenuItem data={{ action: 'toggleIsDev' }}
             onClick={handleTopMenuSelection}>
-            <Checkbox checked={isDeveloper}
+            <Checkbox
+              checked={isDeveloper}
               disabled
               label={<Text color='gray.2'>Display development networks</Text>}
               onClick={(e) => e.preventDefault()}
@@ -189,7 +219,7 @@ export default function Accounts (): React.ReactElement {
 
   return (
     <>
-      {renderTopMenu()}
+      {/* {renderTopMenu()} */}
       {renderAccountMenuItems()}
       {hierarchy.length === 0
         ? (
@@ -239,17 +269,19 @@ export default function Accounts (): React.ReactElement {
                   </Flex>
                 </ContextMenuTrigger>
               </Flex>
-              {
-                Object.keys(groupedAccounts).sort((a) => (a === 'unassigned' ? 1 : -1)).map((did: string, index) => {
-                  return <AccountsContainer
-                    accounts={hasKey(groupedAccounts, did) ? groupedAccounts[did] : []}
-                    did={did}
-                    headerColor={getHeaderColor(index)}
-                    key={index}
-                    selectedAccount={selectedAccount || ''}
-                  />;
-                })
-              }
+              {Object.keys(groupedAccounts)
+                .sort((a) => (a === 'unassigned' ? 1 : -1))
+                .map((did: string, index) => {
+                  return (
+                    <AccountsContainer
+                      accounts={hasKey(groupedAccounts, did) ? groupedAccounts[did] : []}
+                      did={did}
+                      headerColor={getHeaderColor(index)}
+                      key={index}
+                      selectedAccount={selectedAccount || ''}
+                    />
+                  );
+                })}
             </AccountsArea>
           </>
         )}

--- a/packages/ui/src/Popup/Accounts/index.tsx
+++ b/packages/ui/src/Popup/Accounts/index.tsx
@@ -10,8 +10,8 @@ import React, { useCallback, useContext } from 'react';
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
 
-import { AccountContext, Option, OptionSelector, PolymeshContext } from '../../components';
-import { Box, Checkbox, ContextMenuTrigger, Flex, GrowingButton, Header, Icon, Menu, MenuItem, Text } from '../../ui';
+import { AccountContext, PolymeshContext } from '../../components';
+import { Checkbox, ContextMenuTrigger, Flex, GrowingButton, Header, Icon, Menu, MenuItem, Text } from '../../ui';
 import { AccountsContainer } from './AccountsContainer';
 import { AccountsHeader } from './AccountsHeader';
 import AddAccount from './AddAccount';
@@ -187,30 +187,6 @@ export default function Accounts (): React.ReactElement {
     );
   };
 
-  const networkOptions: Option[] = [
-    {
-      label: (
-        <Flex className='network-item'
-          px='16px'
-          py='8px'>
-          <NetworkCircle background={NETWORK_COLORS.itn.backgrounds[0]}
-            color={NETWORK_COLORS.itn.foreground}
-            size='24px'
-            thickness='4px'/>
-          <Box ml='8px'
-            mr='auto'>
-            <Text variant='b2m'>ITN</Text>
-          </Box>
-        </Flex>
-      ),
-      value: 'itn'
-    },
-    {
-      label: 'Alcyone',
-      value: 'pme'
-    }
-  ];
-
   return (
     <>
       {renderTopMenu()}
@@ -226,12 +202,8 @@ export default function Accounts (): React.ReactElement {
                 flexDirection='row'
                 justifyContent='space-between'
                 mb='m'>
-                {/* <NetworkSelector currentNetwork={network}
-                  onSelect={setNetwork} /> */}
-                <OptionSelector options={networkOptions}>
-                  <Text color='white'>Test</Text>
-                </OptionSelector>
-
+                <NetworkSelector currentNetwork={network}
+                  onSelect={setNetwork} />
                 <Flex flexDirection='row'
                   justifyContent='center'>
                   <GrowingButton icon={SvgViewDashboard}
@@ -297,32 +269,3 @@ const AccountsArea = styled.div`
     display: none;
   }
 `;
-
-const NetworkCircle = styled.span<{ background: string; color: string; size?: string; thickness?: string; }>`
-  display: inline-box;
-  width: ${(props) => props.size || '12px'};
-  height: ${(props) => props.size || '12px'};
-  background: ${(props) => props.background};
-  box-sizing: border-box;
-  border: ${(props) => props.thickness || '2px'} solid ${(props) => props.color};
-  border-radius: 50%;
-`;
-
-const DEV_NETWORK_COLORS = {
-  backgrounds: ['#DCEFFE', '#1348E440'],
-  foreground: '#1348E4'
-};
-
-const NETWORK_COLORS: Record<NetworkName, { backgrounds: string[], foreground: string }> = {
-  itn: {
-    backgrounds: ['#F2E6FF', '#4D019840'],
-    foreground: '#4D0198'
-  },
-  alcyone: {
-    backgrounds: ['#FBF3D0', '#E3A30C40'],
-    foreground: '#E3A30C'
-  },
-  pmf: DEV_NETWORK_COLORS,
-  pme: DEV_NETWORK_COLORS,
-  local: DEV_NETWORK_COLORS
-};

--- a/packages/ui/src/Popup/Accounts/index.tsx
+++ b/packages/ui/src/Popup/Accounts/index.tsx
@@ -10,8 +10,8 @@ import React, { useCallback, useContext } from 'react';
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
 
-import { AccountContext, PolymeshContext } from '../../components';
-import { Checkbox, ContextMenuTrigger, Flex, GrowingButton, Header, Icon, Menu, MenuItem, Text } from '../../ui';
+import { AccountContext, Option, OptionSelector, PolymeshContext } from '../../components';
+import { Box, Checkbox, ContextMenuTrigger, Flex, GrowingButton, Header, Icon, Menu, MenuItem, Text } from '../../ui';
 import { AccountsContainer } from './AccountsContainer';
 import { AccountsHeader } from './AccountsHeader';
 import AddAccount from './AddAccount';
@@ -187,6 +187,30 @@ export default function Accounts (): React.ReactElement {
     );
   };
 
+  const networkOptions: Option[] = [
+    {
+      label: (
+        <Flex className='network-item'
+          px='16px'
+          py='8px'>
+          <NetworkCircle background={NETWORK_COLORS.itn.backgrounds[0]}
+            color={NETWORK_COLORS.itn.foreground}
+            size='24px'
+            thickness='4px'/>
+          <Box ml='8px'
+            mr='auto'>
+            <Text variant='b2m'>ITN</Text>
+          </Box>
+        </Flex>
+      ),
+      value: 'itn'
+    },
+    {
+      label: 'Alcyone',
+      value: 'pme'
+    }
+  ];
+
   return (
     <>
       {renderTopMenu()}
@@ -202,8 +226,12 @@ export default function Accounts (): React.ReactElement {
                 flexDirection='row'
                 justifyContent='space-between'
                 mb='m'>
-                <NetworkSelector currentNetwork={network}
-                  onSelect={setNetwork} />
+                {/* <NetworkSelector currentNetwork={network}
+                  onSelect={setNetwork} /> */}
+                <OptionSelector options={networkOptions}>
+                  <Text color='white'>Test</Text>
+                </OptionSelector>
+
                 <Flex flexDirection='row'
                   justifyContent='center'>
                   <GrowingButton icon={SvgViewDashboard}
@@ -269,3 +297,32 @@ const AccountsArea = styled.div`
     display: none;
   }
 `;
+
+const NetworkCircle = styled.span<{ background: string; color: string; size?: string; thickness?: string; }>`
+  display: inline-box;
+  width: ${(props) => props.size || '12px'};
+  height: ${(props) => props.size || '12px'};
+  background: ${(props) => props.background};
+  box-sizing: border-box;
+  border: ${(props) => props.thickness || '2px'} solid ${(props) => props.color};
+  border-radius: 50%;
+`;
+
+const DEV_NETWORK_COLORS = {
+  backgrounds: ['#DCEFFE', '#1348E440'],
+  foreground: '#1348E4'
+};
+
+const NETWORK_COLORS: Record<NetworkName, { backgrounds: string[], foreground: string }> = {
+  itn: {
+    backgrounds: ['#F2E6FF', '#4D019840'],
+    foreground: '#4D0198'
+  },
+  alcyone: {
+    backgrounds: ['#FBF3D0', '#E3A30C40'],
+    foreground: '#E3A30C'
+  },
+  pmf: DEV_NETWORK_COLORS,
+  pme: DEV_NETWORK_COLORS,
+  local: DEV_NETWORK_COLORS
+};

--- a/packages/ui/src/Popup/Accounts/index.tsx
+++ b/packages/ui/src/Popup/Accounts/index.tsx
@@ -130,7 +130,7 @@ export default function Accounts (): React.ReactElement {
 
   const topMenuOptions: Option[] = [
     {
-      options: [
+      menu: [
         { label: 'Change password', value: 'changePassword' },
         { label: 'Open extension in a new tab', value: 'newWindow' },
         {

--- a/packages/ui/src/components/OptionSelector.tsx
+++ b/packages/ui/src/components/OptionSelector.tsx
@@ -5,6 +5,9 @@ import styled from 'styled-components';
 
 import { BoxProps } from '../ui/Box';
 
+const SELECTOR_SPACING = 4;
+const OPTION_SELECTOR_PORTAL_ID = 'option-selector-portal';
+
 type OptionLabel = string | JSX.Element;
 
 type OptionItem = {
@@ -44,8 +47,6 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
   const portalRoot = document.getElementById(OPTION_SELECTOR_PORTAL_ID);
 
   const insertPortalRoot = () => {
-    if (portalRoot) return;
-
     const root = document.getElementById('root');
     const createdPortalRoot = document.createElement('div');
 
@@ -181,6 +182,3 @@ const Options = styled(Box)<{ cssPosition: CssPosition }>`
     }
   }
 `;
-
-const SELECTOR_SPACING = 4;
-const OPTION_SELECTOR_PORTAL_ID = 'option-selector-portal';

--- a/packages/ui/src/components/OptionSelector.tsx
+++ b/packages/ui/src/components/OptionSelector.tsx
@@ -18,14 +18,15 @@ export type Option = {
 };
 
 type OptionSelectorProps = BoxProps &
-PropsWithChildren<{
+{
   options: Option[];
+  selector: string | JSX.Element;
   onSelect: (value: any) => void;
   style?: CSSProperties;
-}>;
+};
 
 export function OptionSelector (props: OptionSelectorProps): JSX.Element {
-  const { children, onSelect, options, style, ...boxProps } = props;
+  const { onSelect, options, selector, style, ...boxProps } = props;
 
   const [isShowingOptions, setIsShowingOptions] = useState(false);
   const [coords, setCoords] = useState({ x: 0, y: 0 });
@@ -84,7 +85,7 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
   return (
     <Box onClick={showOptions}
       ref={wrapperRef}>
-      {children}
+      {selector}
 
       {isShowingOptions && !!portalRoot &&
         ReactDOM.createPortal(

--- a/packages/ui/src/components/OptionSelector.tsx
+++ b/packages/ui/src/components/OptionSelector.tsx
@@ -1,6 +1,8 @@
-import { Flex, Text } from '@polymathnetwork/extension-ui/ui';
-import React, { PropsWithChildren } from 'react';
+import { Box, Flex, Text } from '@polymathnetwork/extension-ui/ui';
+import React, { CSSProperties, PropsWithChildren } from 'react';
 import styled from 'styled-components';
+
+import { BoxProps } from '../ui/Box';
 
 type OptionLabel = string | JSX.Element;
 
@@ -9,12 +11,13 @@ export type Option = {
   value: any;
 };
 
-type OptionSelectorProps = PropsWithChildren<{
+type OptionSelectorProps = BoxProps & PropsWithChildren<{
   options: Option[];
+  style?: CSSProperties;
 }>;
 
 export function OptionSelector (props: OptionSelectorProps): JSX.Element {
-  const { children, options } = props;
+  const { children, options, style, ...boxProps } = props;
 
   const renderOption = (label: OptionLabel) => {
     return typeof label === 'string'
@@ -33,7 +36,8 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
   return (
     <Wrapper>
       {children}
-      <Options>
+      <Options {...boxProps}
+        style={style}>
         <ul>
           {options.map((option, index) => (
             <li key={index}>
@@ -50,7 +54,7 @@ const Wrapper = styled.div`
   position: relative;
 `;
 
-const Options = styled.div`
+const Options = styled(Box)`
   position: absolute;
   background: white;
   box-shadow: ${(props) => props.theme.shadows[3]};
@@ -61,5 +65,14 @@ const Options = styled.div`
     margin: 0;
     padding: 0;
     list-style-type: none;
+
+    li {
+      cursor: pointer;
+      white-space: nowrap;
+
+      &:hover {
+        background: ${(props) => props.theme.colors.gray[5]};
+      }
+    }
   }
 `;

--- a/packages/ui/src/components/OptionSelector.tsx
+++ b/packages/ui/src/components/OptionSelector.tsx
@@ -56,8 +56,6 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
 
     if (!wrapperRect) return;
 
-    console.log({ wrapperRect });
-
     // @TODO add options, or calculate where to render the options: bottom-left, bottom-right, top-left, top-right, etc.
     // Default: bottom-left
     if (position === 'bottom-right') {
@@ -90,11 +88,12 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
   useEffect(() => {
     if (isShowingOptions) {
       document.addEventListener('mousedown', handleClick);
+    } else {
+      portalRoot?.remove();
     }
 
     return () => {
       document.removeEventListener('mousedown', handleClick);
-      portalRoot?.remove();
     };
   }, [isShowingOptions, portalRoot]);
 

--- a/packages/ui/src/components/OptionSelector.tsx
+++ b/packages/ui/src/components/OptionSelector.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Text } from '@polymathnetwork/extension-ui/ui';
-import React, { CSSProperties, Fragment, PropsWithChildren, useEffect, useRef, useState } from 'react';
+import React, { CSSProperties, Fragment, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
 
@@ -25,7 +25,7 @@ type OptionSelectorProps = BoxProps & {
   style?: CSSProperties;
 };
 
-type Position = {
+type CssPosition = {
   top?: string;
   right?: string;
   bottom?: string;
@@ -36,7 +36,7 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
   const { onSelect, options, position, selector, style, ...boxProps } = props;
 
   const [isShowingOptions, setIsShowingOptions] = useState(false);
-  const [placePosition, setPlacePosition] = useState<Position>({});
+  const [cssPosition, setCssPosition] = useState<CssPosition>({});
 
   const wrapperRef = useRef<HTMLDivElement>(null);
   const optionsRef = useRef<HTMLDivElement>(null);
@@ -59,12 +59,12 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
     // @TODO add options, or calculate where to render the options: bottom-left, bottom-right, top-left, top-right, etc.
     // Default: bottom-left
     if (position === 'bottom-right') {
-      setPlacePosition({
+      setCssPosition({
         top: `${wrapperRect.bottom + SELECTOR_SPACING}px`,
         right: `calc(100% - ${wrapperRect.right}px)`
       });
     } else {
-      setPlacePosition({
+      setCssPosition({
         top: `${wrapperRect.bottom + SELECTOR_SPACING}px`,
         left: `${wrapperRect.left}px`
       });
@@ -106,7 +106,7 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
         !!portalRoot &&
         ReactDOM.createPortal(
           <Options {...boxProps}
-            position={placePosition}
+            cssPosition={cssPosition}
             ref={optionsRef}
             style={style}>
             {options.map((option, index) => (
@@ -151,17 +151,18 @@ function renderOptionLabel (label: OptionLabel) {
     );
 }
 
-const Options = styled(Box)<{ position: Position }>`
+const Options = styled(Box)<{ cssPosition: CssPosition }>`
   position: absolute;
-  ${({ position }) => position.top && `top: ${position.top}`};
-  ${({ position }) => position.right && `right: ${position.right}`};
-  ${({ position }) => position.bottom && `bottom: ${position.bottom}`};
-  ${({ position }) => position.left && `left: ${position.left}`};
   background: white;
   box-shadow: ${(props) => props.theme.shadows[3]};
   border-radius: 8px;
   padding: 8px 0;
   z-index: 1000;
+
+  ${({ cssPosition: { top } }) => top && `top: ${top};`}
+  ${({ cssPosition: { right } }) => right && `right: ${right};`}
+  ${({ cssPosition: { bottom } }) => bottom && `bottom: ${bottom};`}
+  ${({ cssPosition: { left } }) => left && `left: ${left};`}
 
   ul {
     margin: 0;

--- a/packages/ui/src/components/OptionSelector.tsx
+++ b/packages/ui/src/components/OptionSelector.tsx
@@ -44,6 +44,8 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
   const portalRoot = document.getElementById(OPTION_SELECTOR_PORTAL_ID);
 
   const insertPortalRoot = () => {
+    if (portalRoot) return;
+
     const root = document.getElementById('root');
     const createdPortalRoot = document.createElement('div');
 
@@ -51,7 +53,7 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
     root?.appendChild(createdPortalRoot);
   };
 
-  const positionOptionsEl = () => {
+  const cssPositionOptionsEl = () => {
     const wrapperRect = wrapperRef.current?.getBoundingClientRect();
 
     if (!wrapperRect) return;
@@ -73,7 +75,7 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
 
   const showOptions = () => {
     insertPortalRoot();
-    positionOptionsEl();
+    cssPositionOptionsEl();
     setIsShowingOptions(true);
   };
 
@@ -140,7 +142,7 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
 function renderOptionLabel (label: OptionLabel) {
   return typeof label === 'string'
     ? (
-      <Flex className='network-item'
+      <Flex
         px='16px'
         py='8px'>
         <Text variant='b2m'>{label}</Text>

--- a/packages/ui/src/components/OptionSelector.tsx
+++ b/packages/ui/src/components/OptionSelector.tsx
@@ -17,13 +17,15 @@ type OptionItem = {
 
 export type Option = {
   category?: string;
-  options: OptionItem[];
+  menu: OptionItem[];
 };
 
 type OptionSelectorProps = BoxProps & {
   options: Option[];
   selector: string | JSX.Element;
   onSelect: (value: any) => void;
+  // @TODO add more positioning options as needed.
+  // Or, add logic to dynamically calculate where to open like a context-menu (will make UI less predictable).
   position?: 'bottom-left' | 'bottom-right';
   style?: CSSProperties;
 };
@@ -36,7 +38,7 @@ type CssPosition = {
 };
 
 export function OptionSelector (props: OptionSelectorProps): JSX.Element {
-  const { onSelect, options, position, selector, style, ...boxProps } = props;
+  const { onSelect, options, position = 'bottom-left', selector, style, ...boxProps } = props;
 
   const [isShowingOptions, setIsShowingOptions] = useState(false);
   const [cssPosition, setCssPosition] = useState<CssPosition>({});
@@ -59,18 +61,17 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
 
     if (!wrapperRect) return;
 
-    // @TODO add options, or calculate where to render the options: bottom-left, bottom-right, top-left, top-right, etc.
-    // Default: bottom-left
-    if (position === 'bottom-right') {
-      setCssPosition({
-        top: `${wrapperRect.bottom + SELECTOR_SPACING}px`,
-        right: `calc(100% - ${wrapperRect.right}px)`
-      });
-    } else {
-      setCssPosition({
-        top: `${wrapperRect.bottom + SELECTOR_SPACING}px`,
-        left: `${wrapperRect.left}px`
-      });
+    switch (position) {
+      case 'bottom-right':
+        return setCssPosition({
+          top: `${wrapperRect.bottom + SELECTOR_SPACING}px`,
+          right: `calc(100% - ${wrapperRect.right}px)`
+        });
+      case 'bottom-left':
+        return setCssPosition({
+          top: `${wrapperRect.bottom + SELECTOR_SPACING}px`,
+          left: `${wrapperRect.left}px`
+        });
     }
   };
 
@@ -105,8 +106,8 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
       ref={wrapperRef}>
       {selector}
 
-      {isShowingOptions &&
-        !!portalRoot &&
+      {portalRoot &&
+        isShowingOptions &&
         ReactDOM.createPortal(
           <Options {...boxProps}
             cssPosition={cssPosition}
@@ -124,10 +125,10 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
                   </Box>
                 )}
                 <ul>
-                  {option.options.map((_option, _index) => (
+                  {option.menu.map((_option, _index) => (
                     <li key={_index}
                       onClick={() => onSelect(_option.value)}>
-                      {renderOptionLabel(_option.label)}
+                      <OptionLabel label={_option.label} />
                     </li>
                   ))}
                 </ul>
@@ -140,11 +141,10 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
   );
 }
 
-function renderOptionLabel (label: OptionLabel) {
+function OptionLabel ({ label }: { label: OptionLabel }) {
   return typeof label === 'string'
     ? (
-      <Flex
-        px='16px'
+      <Flex px='16px'
         py='8px'>
         <Text variant='b2m'>{label}</Text>
       </Flex>
@@ -162,6 +162,7 @@ const Options = styled(Box)<{ cssPosition: CssPosition }>`
   padding: 8px 0;
   z-index: 1000;
 
+  // Add only the necessary css positioning attributes
   ${({ cssPosition: { top } }) => top && `top: ${top};`}
   ${({ cssPosition: { right } }) => right && `right: ${right};`}
   ${({ cssPosition: { bottom } }) => bottom && `bottom: ${bottom};`}

--- a/packages/ui/src/components/OptionSelector.tsx
+++ b/packages/ui/src/components/OptionSelector.tsx
@@ -1,0 +1,65 @@
+import { Flex, Text } from '@polymathnetwork/extension-ui/ui';
+import React, { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+
+type OptionLabel = string | JSX.Element;
+
+export type Option = {
+  label: OptionLabel;
+  value: any;
+};
+
+type OptionSelectorProps = PropsWithChildren<{
+  options: Option[];
+}>;
+
+export function OptionSelector (props: OptionSelectorProps): JSX.Element {
+  const { children, options } = props;
+
+  const renderOption = (label: OptionLabel) => {
+    return typeof label === 'string'
+      ? (
+        <Flex className='network-item'
+          px='16px'
+          py='8px'>
+          <Text variant='b2m'>
+            {label}
+          </Text>
+        </Flex>
+      )
+      : label;
+  };
+
+  return (
+    <Wrapper>
+      {children}
+      <Options>
+        <ul>
+          {options.map((option, index) => (
+            <li key={index}>
+              {renderOption(option.label)}
+            </li>
+          ))}
+        </ul>
+      </Options>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  position: relative;
+`;
+
+const Options = styled.div`
+  position: absolute;
+  background: white;
+  box-shadow: ${(props) => props.theme.shadows[3]};
+  border-radius: 8px;
+  padding: 8px 0;
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+`;

--- a/packages/ui/src/components/OptionSelector.tsx
+++ b/packages/ui/src/components/OptionSelector.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Box, Flex, Text } from '@polymathnetwork/extension-ui/ui';
 import React, { CSSProperties, Fragment, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
@@ -81,7 +82,7 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
     setIsShowingOptions(true);
   };
 
-  const handleClick = (event: MouseEvent) => {
+  const handleClickOutside = (event: MouseEvent) => {
     const hasClickedOutside = !optionsRef.current?.contains(event.target as Node);
 
     if (hasClickedOutside) {
@@ -91,13 +92,13 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
 
   useEffect(() => {
     if (isShowingOptions) {
-      document.addEventListener('mousedown', handleClick);
+      document.addEventListener('mousedown', handleClickOutside);
     } else {
       portalRoot?.remove();
     }
 
     return () => {
-      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [isShowingOptions, portalRoot]);
 
@@ -113,8 +114,9 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
             cssPosition={cssPosition}
             ref={optionsRef}
             style={style}>
-            {options.map((option, index) => (
-              <Fragment key={index}>
+            {/* Render option menus */}
+            {options.map((option, optionIndex) => (
+              <Fragment key={optionIndex}>
                 {option.category && (
                   <Box mx='16px'
                     textAlign='left'>
@@ -125,10 +127,20 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
                   </Box>
                 )}
                 <ul>
-                  {option.menu.map((_option, _index) => (
-                    <li key={_index}
-                      onClick={() => onSelect(_option.value)}>
-                      <OptionLabel label={_option.label} />
+                  {/* Render menu items */}
+                  {option.menu.map((optionItem, optionItemIndex) => (
+                    <li key={optionItemIndex}
+                      onClick={() => onSelect(optionItem.value)}>
+                      {typeof optionItem.label === 'string'
+                        ? (
+                          <Flex px='16px'
+                            py='8px'>
+                            <Text variant='b2m'>{optionItem.label}</Text>
+                          </Flex>
+                        )
+                        : (
+                          optionItem.label
+                        )}
                     </li>
                   ))}
                 </ul>
@@ -139,19 +151,6 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
         )}
     </Box>
   );
-}
-
-function OptionLabel ({ label }: { label: OptionLabel }) {
-  return typeof label === 'string'
-    ? (
-      <Flex px='16px'
-        py='8px'>
-        <Text variant='b2m'>{label}</Text>
-      </Flex>
-    )
-    : (
-      label
-    );
 }
 
 const Options = styled(Box)<{ cssPosition: CssPosition }>`

--- a/packages/ui/src/components/OptionSelector.tsx
+++ b/packages/ui/src/components/OptionSelector.tsx
@@ -4,6 +4,7 @@ import React, { CSSProperties, Fragment, useEffect, useRef, useState } from 'rea
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
 
+import { ThemeProps } from '../types';
 import { BoxProps } from '../ui/Box';
 
 const SELECTOR_SPACING = 4;
@@ -153,7 +154,7 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
   );
 }
 
-const Options = styled(Box)<{ cssPosition: CssPosition }>`
+const Options = styled(Box)<{ cssPosition: CssPosition } & ThemeProps>`
   position: absolute;
   background: white;
   box-shadow: ${(props) => props.theme.shadows[3]};
@@ -177,7 +178,7 @@ const Options = styled(Box)<{ cssPosition: CssPosition }>`
       white-space: nowrap;
 
       &:hover {
-        background: ${(props) => props.theme.colors.gray[5]};
+        background: ${(props) => props.theme.colors.gray[4]};
       }
     }
   }

--- a/packages/ui/src/components/OptionSelector.tsx
+++ b/packages/ui/src/components/OptionSelector.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Text } from '@polymathnetwork/extension-ui/ui';
-import React, { CSSProperties, PropsWithChildren } from 'react';
+import React, { CSSProperties, MouseEventHandler, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
 import { BoxProps } from '../ui/Box';
@@ -13,11 +13,12 @@ export type Option = {
 
 type OptionSelectorProps = BoxProps & PropsWithChildren<{
   options: Option[];
+  onSelect: (value: any) => void;
   style?: CSSProperties;
 }>;
 
 export function OptionSelector (props: OptionSelectorProps): JSX.Element {
-  const { children, options, style, ...boxProps } = props;
+  const { children, onSelect, options, style, ...boxProps } = props;
 
   const renderOption = (label: OptionLabel) => {
     return typeof label === 'string'
@@ -40,7 +41,8 @@ export function OptionSelector (props: OptionSelectorProps): JSX.Element {
         style={style}>
         <ul>
           {options.map((option, index) => (
-            <li key={index}>
+            <li key={index}
+              onClick={() => onSelect(option.value)}>
               {renderOption(option.label)}
             </li>
           ))}

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -8,6 +8,7 @@ export { default as Warning } from './Warning';
 export { default as ErrorFallback } from './ErrorFallback';
 export { Password } from './Password';
 export { AccountType } from './AccountType';
+export { OptionSelector, Option } from './OptionSelector';
 
 export * from './contexts';
 export * from './themes';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -8,7 +8,7 @@ export { default as Warning } from './Warning';
 export { default as ErrorFallback } from './ErrorFallback';
 export { Password } from './Password';
 export { AccountType } from './AccountType';
-export { OptionSelector, Option } from './OptionSelector';
+export { OptionSelector } from './OptionSelector';
 
 export * from './contexts';
 export * from './themes';


### PR DESCRIPTION
- created OptionSelector component that shows dropdown options that can be attached to any component
  - can add categories for options. E.g. "Networks", "Developer" text in the network selector options — this segregration is not included in this PR, just as an example:
  <p align="center">
    <img src="https://user-images.githubusercontent.com/7417976/115441666-1d858280-a1df-11eb-9cf2-56bdc49e9765.png" width="400" />
  </>
- refactor NetworkSelector to use OptionSelector
- replace context-menu with OptionSelector for top menu options:
  <p align="center">
    <img src="https://user-images.githubusercontent.com/7417976/115442059-94bb1680-a1df-11eb-9e8e-95c448735dc7.png" width="400" />
  </p>
- currently OptionSelector supports opening in bottom-left and bottom-right positions. More positioning options can be added as needed
  - specifying positions also makes UI more predictable, especially for button clicks. But it is unlike a context-menu where it calculates where to open based on click coordinates. This is especially good for showing right-click options in an area, but for button clicks the position is already deterministic. Nonetheless, this functionality to calculate opening position can also be added in the future if needed
