### PR TITLE
[WAL-168] Change the source of the messages that are send from injected script

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.5.4"
+  "version": "0.5.5"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymesh-wallet",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A Wallet extension for Polymesh blockchain",
   "private": true,
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymathnetwork/extension-core",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/core/src/background/handlers/index.ts
+++ b/packages/core/src/background/handlers/index.ts
@@ -16,7 +16,7 @@ export default function handler<TMessageType extends PolyMessageTypes> (
 ): void {
   const isExtension = port.name === PORTS.EXTENSION;
   const sender = port.sender as chrome.runtime.MessageSender;
-  const from = isExtension ? 'extension' : (sender.tab && sender.tab.url) || sender.url || '<unknown>';
+  const from = isExtension ? PORTS.EXTENSION : (sender.tab && sender.tab.url) || sender.url || '<unknown>';
   const source = `${from}: ${id}: ${message}`;
 
   console.log(` [in] ${source}`); // :: ${JSON.stringify(request)}`);

--- a/packages/core/src/background/types.ts
+++ b/packages/core/src/background/types.ts
@@ -1,6 +1,7 @@
 import { AccountJson, RequestSignatures as DotRequestSignatures } from '@polkadot/extension-base/background/types';
 import { FunctionMetadataLatest } from '@polkadot/types/interfaces';
 import { AnyJson, SignerPayloadJSON } from '@polkadot/types/types';
+import { ORIGINS } from '@polymathnetwork/extension-core/constants';
 
 import { IdentifiedAccount,
   NetworkMeta,
@@ -196,6 +197,26 @@ export type PolyResponseType<TMessageType extends keyof PolyRequestSignatures> =
 export interface PolyTransportRequestMessage<TMessageType extends PolyMessageTypes> {
   id: string;
   message: TMessageType;
-  origin: 'page' | 'extension';
+  origin: ORIGINS.PAGE | ORIGINS.EXTENSION;
   request: PolyRequestTypes[TMessageType];
 }
+
+interface PolyTransportResponseMessageNoSub<TMessageType extends PolyMessageTypesWithNoSubscriptions> {
+  error?: string;
+  id: string;
+  response?: PolyResponseTypes[TMessageType];
+}
+
+interface PolyTransportResponseMessageSub<TMessageType extends PolyMessageTypesWithSubscriptions> {
+  error?: string;
+  id: string;
+  response?: PolyResponseTypes[TMessageType];
+  subscription?: PolySubscriptionMessageTypes[TMessageType];
+}
+
+export type PolyTransportResponseMessage<TMessageType extends PolyMessageTypes> =
+  TMessageType extends PolyMessageTypesWithNoSubscriptions
+    ? PolyTransportResponseMessageNoSub<TMessageType>
+    : TMessageType extends PolyMessageTypesWithSubscriptions
+      ? PolyTransportResponseMessageSub<TMessageType>
+      : never;

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -95,3 +95,10 @@ export const PORTS = {
   EXTENSION: 'polywallet_extension',
   CONTENT: 'polywallet_content'
 };
+
+export enum ORIGINS {
+  EXTENSION = 'polywallet_extension',
+  PAGE = 'polywallet_page'
+}
+
+export const PASSWORD_EXPIRY_MIN = 15;

--- a/packages/core/src/page/index.ts
+++ b/packages/core/src/page/index.ts
@@ -1,9 +1,69 @@
-import { sendMessage } from '@polkadot/extension-base/page';
 
+import { PolyMessageTypes, PolyMessageTypesWithNoSubscriptions, PolyMessageTypesWithNullRequest, PolyMessageTypesWithSubscriptions, PolyRequestTypes, PolyResponseTypes, PolySubscriptionMessageTypes, PolyTransportRequestMessage, PolyTransportResponseMessage } from '../background/types';
+import { ORIGINS } from '../constants';
 import PolymeshInjected from './injected';
+
+export interface Handler {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  resolve: (data?: any) => void;
+  reject: (error: Error) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  subscriber?: (data: any) => void;
+}
+
+export type Handlers = Record<string, Handler>;
+
+const handlers: Handlers = {};
+let idCounter = 0;
+
+// a generic message sender that creates an event, returning a promise that will
+// resolve once the event is resolved (by the response listener just below this)
+export function sendMessage<TMessageType extends PolyMessageTypesWithNullRequest>(message: TMessageType): Promise<PolyResponseTypes[TMessageType]>;
+export function sendMessage<TMessageType extends PolyMessageTypesWithNoSubscriptions>(message: TMessageType, request: PolyRequestTypes[TMessageType]): Promise<PolyResponseTypes[TMessageType]>;
+export function sendMessage<TMessageType extends PolyMessageTypesWithSubscriptions>(message: TMessageType, request: PolyRequestTypes[TMessageType], subscriber: (data:PolySubscriptionMessageTypes[TMessageType]) => void): Promise<PolyResponseTypes[TMessageType]>;
+
+export function sendMessage<TMessageType extends PolyMessageTypes> (message: TMessageType, request?: PolyRequestTypes[TMessageType], subscriber?: (data: unknown) => void): Promise<PolyResponseTypes[TMessageType]> {
+  return new Promise((resolve, reject): void => {
+    const id = `${Date.now()}.${++idCounter}`;
+
+    handlers[id] = { reject, resolve, subscriber };
+
+    const transportRequestMessage: PolyTransportRequestMessage<TMessageType> = {
+      id,
+      message,
+      origin: ORIGINS.PAGE,
+      request: request || null as PolyRequestTypes[TMessageType]
+    };
+
+    window.postMessage(transportRequestMessage, '*');
+  });
+}
 
 export async function enable (origin: string): Promise<PolymeshInjected> {
   await sendMessage('pub(authorize.tab)', { origin });
 
   return new PolymeshInjected(sendMessage);
+}
+
+export function handleResponse<TMessageType extends PolyMessageTypes> (data: PolyTransportResponseMessage<TMessageType> & { subscription?: string }): void {
+  const handler = handlers[data.id];
+
+  if (!handler) {
+    console.error(`Unknown response: ${JSON.stringify(data)}`);
+
+    return;
+  }
+
+  if (!handler.subscriber) {
+    delete handlers[data.id];
+  }
+
+  if (data.subscription) {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    (handler.subscriber as Function)(data.subscription);
+  } else if (data.error) {
+    handler.reject(new Error(data.error));
+  } else {
+    handler.resolve(data.response);
+  }
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polymathnetwork/extension",
   "description": "A Wallet extension for Polymesh blockchain",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "dependencies": {
     "@babel/runtime": "^7.12.13",
@@ -14,8 +14,8 @@
     "@polkadot/phishing": "^0.6.1",
     "@polkadot/ui-keyring": "^0.70.1",
     "@polkadot/ui-settings": "^0.70.1",
-    "@polymathnetwork/extension-core": "0.5.4",
-    "@polymathnetwork/extension-ui": "0.5.4"
+    "@polymathnetwork/extension-core": "0.5.5",
+    "@polymathnetwork/extension-ui": "0.5.5"
   },
   "devDependencies": {
     "@polkadot/dev": "^0.61.30",

--- a/packages/extension/src/content.ts
+++ b/packages/extension/src/content.ts
@@ -1,6 +1,6 @@
 import { Message } from '@polkadot/extension-base/types';
 import chrome from '@polkadot/extension-inject/chrome';
-import { PORTS } from '@polymathnetwork/extension-core/constants';
+import { ORIGINS, PORTS } from '@polymathnetwork/extension-core/constants';
 
 // connect to the extension
 const port = chrome.runtime.connect({ name: PORTS.CONTENT });
@@ -13,7 +13,7 @@ port.onMessage.addListener((data): void => {
 // all messages from the page, pass them to the extension
 window.addEventListener('message', ({ data, source }: Message): void => {
   // only allow messages from our window, by the inject
-  if (source !== window || data.origin !== 'page') {
+  if (source !== window || data.origin !== ORIGINS.PAGE) {
     return;
   }
 

--- a/packages/extension/src/page.ts
+++ b/packages/extension/src/page.ts
@@ -1,8 +1,7 @@
-import { handleResponse } from '@polkadot/extension-base/page';
 import { Message } from '@polkadot/extension-base/types';
 import { injectExtension } from '@polkadot/extension-inject';
 import { PORTS } from '@polymathnetwork/extension-core/constants';
-import { enable } from '@polymathnetwork/extension-core/page';
+import { enable, handleResponse } from '@polymathnetwork/extension-core/page';
 
 // setup a response listener (events created by the loader for extension responses)
 window.addEventListener('message', ({ data, source }: Message): void => {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polymathnetwork/extension-ui",
   "description": "A sample signer extension for the @polkadot/api",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "license": "Apache-2",
   "type": "module",
   "dependencies": {

--- a/packages/ui/src/Popup/Signing/SignArea.tsx
+++ b/packages/ui/src/Popup/Signing/SignArea.tsx
@@ -1,4 +1,4 @@
-import { PASSWORD_EXPIRY_MIN } from '@polkadot/extension-base/defaults';
+import { PASSWORD_EXPIRY_MIN } from '@polymathnetwork/extension-core/constants';
 import { ActionContext } from '@polymathnetwork/extension-ui/components';
 import { Box, Button, Checkbox, Flex } from '@polymathnetwork/extension-ui/ui';
 import React, { useCallback, useContext, useEffect, useState } from 'react';


### PR DESCRIPTION
The goal of this PR is not punish our users by having them disable Polkadot, ChainX, or any wallet that exposes the same API. While that requirement/restriction is ok to apply on our own app, we cannot force 3rd party developers to block users that have non-Polymesh wallets installed.

This PR changes the source property of messages coming from the injected script, in order to distinguish them from Polkadot's. It enables users to have have both wallets installed, and even authorized on a dapp, but as long as the dapp targets `polywallet` injected object, things should work fine. 

You can test the PR against [mock-uid-provider](https://polymathnetwork.github.io/mock-uid-provider/) tool, while having both wallets installed and authorized.

Before 
<img width="996" alt="Screen Shot 2021-04-21 at 2 58 55 PM" src="https://user-images.githubusercontent.com/1994818/115628963-4d538980-a2b6-11eb-89e6-5ec20538f078.png">

After
<img width="996" alt="Screen Shot 2021-04-21 at 2 59 45 PM" src="https://user-images.githubusercontent.com/1994818/115628982-56445b00-a2b6-11eb-915d-5ffedcb40e84.png">
