### PR TITLE
Fix password change logic

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.5.5"
+  "version": "0.5.6"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymesh-wallet",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "A Wallet extension for Polymesh blockchain",
   "private": true,
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymathnetwork/extension-core",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/core/src/background/types.ts
+++ b/packages/core/src/background/types.ts
@@ -155,6 +155,7 @@ export interface PolyRequestSignatures extends DotRequestSignatures {
   'poly:pri(global.changePass)': [RequestPolyGlobalChangePass, boolean];
   'poly:pri(password.isSet)': [RequestPolyIsPasswordSet, boolean];
   'poly:pri(password.validate)': [RequestPolyValidatePassword, boolean];
+  'poly:pri(window.open)': [AllowedPath, boolean];
   // public/external requests, i.e. from a page
   'poly:pub(network.get)': [RequestPolyNetworkGet, NetworkMeta];
   'poly:pub(network.subscribe)': [RequestPolyNetworkMetaSubscribe, boolean, NetworkMeta];
@@ -220,3 +221,7 @@ export type PolyTransportResponseMessage<TMessageType extends PolyMessageTypes> 
     : TMessageType extends PolyMessageTypesWithSubscriptions
       ? PolyTransportResponseMessageSub<TMessageType>
       : never;
+
+export const ALLOWED_PATH = ['/', '/account/import-ledger', '/account/restore-json', '/account/change-password'];
+
+export declare type AllowedPath = typeof ALLOWED_PATH[number];

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polymathnetwork/extension",
   "description": "A Wallet extension for Polymesh blockchain",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "dependencies": {
     "@babel/runtime": "^7.13.17",
@@ -14,8 +14,8 @@
     "@polkadot/phishing": "^0.6.110",
     "@polkadot/ui-keyring": "^0.75.1",
     "@polkadot/ui-settings": "^0.75.1",
-    "@polymathnetwork/extension-core": "0.5.5",
-    "@polymathnetwork/extension-ui": "0.5.5"
+    "@polymathnetwork/extension-core": "0.5.6",
+    "@polymathnetwork/extension-ui": "0.5.6"
   },
   "devDependencies": {
     "@polkadot/dev": "^0.62.10",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polymathnetwork/extension-ui",
   "description": "A sample signer extension for the @polkadot/api",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "license": "Apache-2",
   "type": "module",
   "dependencies": {

--- a/packages/ui/src/Popup/Accounts/index.tsx
+++ b/packages/ui/src/Popup/Accounts/index.tsx
@@ -130,7 +130,9 @@ export default function Accounts (): React.ReactElement {
   const handleTopMenuSelection = (value: string) => {
     switch (value) {
       case 'changePassword':
-        return history.push('/account/change-password');
+        return isPopup
+          ? windowOpen('/account/change-password')
+          : history.push('/account/change-password');
       case 'newWindow':
         return windowOpen('/');
       case 'toggleIsDev':

--- a/packages/ui/src/Popup/ChangePassword/index.tsx
+++ b/packages/ui/src/Popup/ChangePassword/index.tsx
@@ -32,9 +32,13 @@ export const ChangePassword: FC = () => {
       return;
     }
 
-    await globalChangePass(data.currentPassword, data.currentPassword);
+    const ret = await globalChangePass(data.currentPassword, data.confirmPassword);
 
-    onAction('/');
+    if (ret) {
+      onAction('/');
+    } else {
+      setError('confirmPassword', { type: 'failed' });
+    }
   };
 
   return (
@@ -112,6 +116,7 @@ export const ChangePassword: FC = () => {
                     {(errors.confirmPassword).type === 'required' && 'Required field'}
                     {(errors.confirmPassword).type === 'minLength' && 'Password too short'}
                     {(errors.confirmPassword).type === 'manual' && 'Passwords do not match'}
+                    {(errors.confirmPassword).type === 'failed' && 'Password change failed - Please contact Polymath support.'}
                   </Text>
                 </Box>
               }

--- a/packages/ui/src/messaging.ts
+++ b/packages/ui/src/messaging.ts
@@ -1,5 +1,4 @@
 import { AccountJson,
-  AllowedPath,
   AuthorizeRequest,
   MessageTypes,
   MessageTypesWithNoSubscriptions,
@@ -20,7 +19,7 @@ import chrome from '@polkadot/extension-inject/chrome';
 import { KeyringPair$Json } from '@polkadot/keyring/types';
 import { SignerPayloadJSON } from '@polkadot/types/types';
 import { KeypairType } from '@polkadot/util-crypto/types';
-import { PolyMessageTypes,
+import { AllowedPath, PolyMessageTypes,
   PolyMessageTypesWithNoSubscriptions,
   PolyMessageTypesWithNullRequest,
   PolyMessageTypesWithSubscriptions,
@@ -359,7 +358,7 @@ export async function validateSeed (suri: string, type?: KeypairType): Promise<{
 }
 
 export async function windowOpen (path: AllowedPath): Promise<boolean> {
-  return sendMessage('pri(window.open)', path);
+  return polyMessage('poly:pri(window.open)', path);
 }
 
 export async function validateDerivationPath (


### PR DESCRIPTION
- Fix a bug where old password were used as the new password, rendering password change operation useless.
- Open password change screen in a separate tab, to make the operation less likely to interrupt.
- Filter ledger accounts out of the accounts the receive password change.
- Inform user to contact Polymath if password change failed. We will have to help them more closely in that case.