### PR TITLE
Distinguish extension body in new tabs

### DIFF
--- a/packages/extension/public/index.html
+++ b/packages/extension/public/index.html
@@ -20,9 +20,10 @@
         padding: 0;
         text-align: left;
         width: 400px;
-        height: calc(100% - 2px);
+        height: 600px;
         max-width: 100%;
         min-width: 400px;
+        box-shadow: 0px 1px 2px rgba(21, 41, 53, 0.24), 0px 1px 3px rgba(21, 41, 53, 0.12);
       "
     ></div>
     <script src="./extension.js"></script>

--- a/packages/extension/public/notification.html
+++ b/packages/extension/public/notification.html
@@ -20,9 +20,10 @@
         padding: 0;
         text-align: left;
         width: 400px;
-        height: calc(100% - 2px);
+        height: 600px;
         max-width: 100%;
         min-width: 400px;
+        box-shadow: 0px 1px 2px rgba(21, 41, 53, 0.24), 0px 1px 3px rgba(21, 41, 53, 0.12);
       "
     ></div>
     <script src="./extension.js"></script>


### PR DESCRIPTION
This PR adds styling to distinguish the extension body in new tabs:

<img width="1552" alt="Screen Shot 2021-05-05 at 17 42 37" src="https://user-images.githubusercontent.com/7417976/117213955-49515c80-adca-11eb-8593-19a5b69747d0.png">

- add box-shadow to root element
- set root element height to also be 600px

I am not sure why the root element was set to be 2px less than the body, I've changed it to match the body at 600px. Let me know if it is a requirement, and I can change it back!
