### PR TITLE
toggle checkbox by clicking label text

### DIFF
--- a/packages/ui/src/ui/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/ui/Checkbox/Checkbox.tsx
@@ -37,14 +37,14 @@ export const Checkbox: FC<Props> = ({ checked,
     checkedProps = { defaultChecked };
   }
 
-  const handleChange = (e: any) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (onChange) {
       onChange(e.currentTarget.checked);
     }
   };
 
   return (
-    <label>
+    <Label>
       <InlineFlex>
         <sc.Input
           {...other}
@@ -74,10 +74,10 @@ export const Checkbox: FC<Props> = ({ checked,
         </sc.CheckboxInput>
         {label && (
           <InlineFlex ml={2}>
-            <Label htmlFor={name}>{label}</Label>
+            {label}
           </InlineFlex>
         )}
       </InlineFlex>
-    </label>
+    </Label>
   );
 };

--- a/packages/ui/src/ui/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/ui/Checkbox/Checkbox.tsx
@@ -44,7 +44,7 @@ export const Checkbox: FC<Props> = ({ checked,
   };
 
   return (
-    <Label>
+    <Label htmlFor={name}>
       <InlineFlex>
         <sc.Input
           {...other}


### PR DESCRIPTION
Quick fix to enable checkbox toggling by clicking label text. Main changes are:

- use only one `label` element
  - the nested `label`s were causing the issue where clicking the label text wouldn't automatically trigger the checkbox, _if_ a name is not provided.
- fix lint warning