### PR TITLE
fix: Import Ledger account popup

### DIFF
--- a/packages/ui/src/Popup/Accounts/index.tsx
+++ b/packages/ui/src/Popup/Accounts/index.tsx
@@ -103,7 +103,7 @@ export default function Accounts(): React.ReactElement {
         return isPopup ? _openWindow(jsonPath) : history.push(jsonPath);
       case 'fromLedger':
       case 'connectLedger':
-        return _openWindow(ledgerPath);
+        return isPopup ? _openWindow(ledgerPath) : history.push(ledgerPath);
     }
   };
 

--- a/packages/ui/src/Popup/Accounts/index.tsx
+++ b/packages/ui/src/Popup/Accounts/index.tsx
@@ -146,7 +146,7 @@ export default function Accounts(): React.ReactElement {
               />
             </Flex>
             {Object.keys(groupedAccounts)
-              .sort((a) => (a === 'unassigned' ? -1 : 1))
+              .sort((a) => (a === 'unassigned' ? 1 : -1))
               .map((did: string, index) => {
                 return (
                   <AccountsContainer

--- a/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
+++ b/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
@@ -289,25 +289,29 @@ function ImportLedger(): React.ReactElement {
                       <Text color="gray.1" variant="b2m">
                         Account type
                       </Text>
-                      <Dropdown
-                        className="accountType"
-                        disabled={ledgerLoading}
-                        onChange={updateAccountIndex}
-                        options={accOps.current}
-                        value={accountIndex}
-                      />
+                      <Box mb="3px">
+                        <Dropdown
+                          className="accountType"
+                          disabled={ledgerLoading}
+                          onChange={updateAccountIndex}
+                          options={accOps.current}
+                          value={accountIndex}
+                        />
+                      </Box>
                     </Box>
                     <Box mb="m">
                       <Text color="gray.1" variant="b2m">
                         Address index
                       </Text>
-                      <Dropdown
-                        className="accountIndex"
-                        disabled={ledgerLoading}
-                        onChange={updateAddressOffset}
-                        options={addOps.current}
-                        value={addressOffset}
-                      />
+                      <Box mb="3px">
+                        <Dropdown
+                          className="accountIndex"
+                          disabled={ledgerLoading}
+                          onChange={updateAddressOffset}
+                          options={addOps.current}
+                          value={addressOffset}
+                        />
+                      </Box>
                     </Box>
                   </>
                 )}

--- a/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
+++ b/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
@@ -11,6 +11,7 @@ import {
   AccountContext,
   ActionContext,
   ActivityContext,
+  PolymeshContext,
 } from '@polymathnetwork/extension-ui/components/contexts';
 import Dropdown from '@polymathnetwork/extension-ui/components/Dropdown';
 import {
@@ -63,6 +64,7 @@ function ImportLedger(): React.ReactElement {
   const { accounts } = useContext(AccountContext);
   const onAction = useContext(ActionContext);
   const isBusy = useContext(ActivityContext);
+  const { networkState } = useContext(PolymeshContext);
 
   const ledgerData = useLedger(genesis, accountIndex, addressOffset);
 
@@ -72,11 +74,12 @@ function ImportLedger(): React.ReactElement {
     refresh,
     status,
   } = ledgerData;
+
   const address: string | null = useMemo(() => {
     if (ledgerAddress) {
       settings.set({ ledgerConn: 'webusb' });
 
-      return recodeAddress(ledgerAddress);
+      return recodeAddress(ledgerAddress, networkState.ss58Format);
     } else {
       return null;
     }

--- a/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
+++ b/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
@@ -204,7 +204,7 @@ function ImportLedger(): React.ReactElement {
               alignItems="flex-start"
               flexDirection="column"
               height="100%"
-              p="8px"
+              p="m"
               style={{ overflowY: 'scroll ' }}
             >
               <Flex width="100%">

--- a/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
+++ b/packages/ui/src/Popup/ImportLedger/ImportLedger.tsx
@@ -14,6 +14,7 @@ import {
   PolymeshContext,
 } from '@polymathnetwork/extension-ui/components/contexts';
 import Dropdown from '@polymathnetwork/extension-ui/components/Dropdown';
+import { InitialsAvatar } from '@polymathnetwork/extension-ui/components/InitialsAvatar';
 import {
   Status,
   useLedger,
@@ -174,14 +175,6 @@ function ImportLedger(): React.ReactElement {
     saveAccount();
   };
 
-  const getInitials = (fullName: string) => {
-    if (!fullName) return '';
-
-    const [name1, name2] = fullName.split(' ');
-
-    return `${name1[0]}${name2 ? name2[0] : ''}`.toUpperCase();
-  };
-
   const toggleShowingSettings = () => {
     setIsShowingSettings(!isShowingSettings);
   };
@@ -222,9 +215,7 @@ function ImportLedger(): React.ReactElement {
                   height={40}
                   justifyContent="center"
                 >
-                  <Text color="brandMain" fontSize={1}>
-                    {getInitials(name)}
-                  </Text>
+                  <InitialsAvatar name={name} />
                 </Flex>
                 <Flex alignItems="flex-start" flexDirection="column" ml="8px">
                   <Text color="gray.1" variant="b2m">

--- a/packages/ui/src/components/Dropdown.tsx
+++ b/packages/ui/src/components/Dropdown.tsx
@@ -75,8 +75,8 @@ export default React.memo(
     -moz-appearance: none;
     appearance: none;
     background: ${theme.readonlyInputBackground};
-    border-color: ${isError ? theme.errorBorderColor : theme.colors.gray[3]};
-    border-radius: ${theme.radii[1]};
+    border-color: ${isError ? theme.errorBorderColor : theme.colors.gray5};
+    border-radius: ${theme.radii[3]};
     border-style: solid;
     border-width: 1px;
     box-sizing: border-box;


### PR DESCRIPTION
- show correct address format on Mainnet for Ledger account imports
- update UI on Ledger account imports
- prevent opening Ledger imports on new tabs, if already in a tab
- move the "Unassigned keys" group back to the bottom
- refactor code
<img width="400" alt="Screen Shot 2021-11-17 at 21 56 03" src="https://user-images.githubusercontent.com/7417976/142377357-81d14fc4-36e6-4616-9996-a0dd18265a97.png">

