### PR TITLE
fix: use localhost link for dashboard for local network

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -34,8 +34,8 @@ export const networkLinks: Record<NetworkName, Record<LinkName, string>> = {
     explorer: 'https://polymesh-testnet.subscan.io/',
   },
   local: {
-    dashboard: 'unknown',
-    explorer: 'unknown',
+    dashboard: 'http://localhost:3000',
+    explorer: '',
   },
 };
 

--- a/packages/ui/src/Popup/AppHeader/AppHeader.tsx
+++ b/packages/ui/src/Popup/AppHeader/AppHeader.tsx
@@ -53,7 +53,9 @@ const AppHeader = (props: Props): ReactElement<Props> => {
   };
 
   const openDashboard = useCallback(() => {
-    chrome.tabs.create({ url: networkLinks[selectedNetwork].dashboard });
+    const url = networkLinks[selectedNetwork].dashboard;
+
+    if (url) chrome.tabs.create({ url });
   }, [selectedNetwork]);
 
   const topMenuOptions: Option[] = [


### PR DESCRIPTION
Clicking "Go to Dashboard" link on wallet when connected to "Local" network, it opens a page to "http://localhost:3000"

![CleanShot 2022-01-20 at 17 32 43](https://user-images.githubusercontent.com/7417976/150432858-0c74cad2-84ff-49bb-bb5a-9c9f7f20abb8.gif)
